### PR TITLE
Reactive Key for use_query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_query"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cfg-if",
  "gloo-timers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,7 @@ dependencies = [
  "gloo-timers",
  "js-sys",
  "leptos",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +830,7 @@ name = "leptos_query"
 version = "0.1.1"
 dependencies = [
  "cfg-if",
+ "gloo-timers",
  "js-sys",
  "leptos",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/nicoburniske/leptos_query"
 leptos = "0.4.3"
 cfg-if = "1"
 js-sys = {version = "0.3.64", optional = true}
+gloo-timers = { version = "0.2.6", features = ["futures"] }
 
 [features]
 hydrate = ["dep:js-sys"] 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ repository = "https://github.com/nicoburniske/leptos_query"
 leptos = "0.4.3"
 cfg-if = "1"
 js-sys = {version = "0.3.64", optional = true}
-gloo-timers = { version = "0.2.6", features = ["futures"] }
+gloo-timers = { version = "0.2.6", optional = true, features = ["futures"] }
+tokio = { version = "1.29.1", optional = true, features = ["time"]}
 
 [features]
-hydrate = ["dep:js-sys"] 
+hydrate = ["dep:js-sys", "dep:gloo-timers"] 
+ssr = ["dep:tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_query"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Nico Burniske"]
 description = "Async query manager for Leptos"

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ TLDR: Wrap your key in a [Newtype](https://doc.rust-lang.org/rust-by-example/gen
 
  // Monkey fetcher.
  async fn get_monkey(id: MonkeyId) -> Monkey {
- ...
+    todo!()
  }
 
  // Query for a Monkey.
- fn use_monkey_query(cx: Scope, id: MonkeyId) -> QueryResult<Monkey> {
+ fn use_monkey_query(cx: Scope, id: impl Fn() -> MonkeyId + 'static) -> QueryResult<Monkey> {
      leptos_query::use_query(
          cx,
          id,
@@ -86,7 +86,7 @@ Now you can use the query in any component in your app.
 
 #[component]
 fn MonkeyView(cx: Scope, id: MonkeyId) -> impl IntoView {
-    let query = use_monkey_query(cx, id);
+    let query = use_monkey_query(cx, move || id.clone());
     let QueryResult {
         data,
         is_loading,

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ fn MonkeyView(cx: Scope, id: MonkeyId) -> impl IntoView {
     let QueryResult {
         data,
         is_loading,
-        is_refetching,
+        is_fetching,
         is_stale
         ..
     } = query;
@@ -106,7 +106,7 @@ fn MonkeyView(cx: Scope, id: MonkeyId) -> impl IntoView {
            <div>
                <span>"Fetching Status: "</span>
                <span>
-                   {move || { if is_refetching.get() { "Fetching..." } else { "Idle" } }}
+                   {move || { if is_fetching.get() { "Fetching..." } else { "Idle" } }}
                </span>
            </div>
            <div>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Leptos Query
 
+[![Crates.io](https://img.shields.io/crates/v/leptos_query.svg)](https://crates.io/crates/leptos_query)
+
 Leptos Query is a asynchronous state management library for [Leptos](https://github.com/leptos-rs/leptos).
 
 Heavily inspired by [Tanstack Query](https://tanstack.com/query/latest/).
@@ -18,7 +20,25 @@ A Query provides:
 ## Installation
 
 ```bash
-cargo add leptos_query
+cargo add leptos_query --optional
+```
+
+Then add the relevant feature(s) to your `Cargo.toml`
+
+`...` meaning the rest of the dependencies you may have.
+
+```toml
+
+[features]
+hydrate = [
+    "leptos_query/hydrate",
+    # ...
+]
+ssr = [
+    "leptos_query/ssr",
+    # ...
+ ]
+
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ TLDR: Wrap your key in a [Newtype](https://doc.rust-lang.org/rust-by-example/gen
      leptos_query::use_query(
          cx,
          id,
-         |id| async move { get_monkey(id).await },
+         get_monkey,
          QueryOptions {
              default_value: None,
              refetch_interval: None,

--- a/example/start-axum/Cargo.toml
+++ b/example/start-axum/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.38"
 tracing = { version = "0.1.37", optional = true }
 http = "0.2.8"
 serde = "1.0.171"
-leptos_query = { path = "../../" }
+leptos_query = { path = "../../", optional = true}
 
 [features]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate", "leptos_query/hydrate"]
@@ -38,6 +38,7 @@ ssr = [
     "leptos/ssr",
     "leptos_meta/ssr",
     "leptos_router/ssr",
+    "leptos_query/ssr",
     "dep:tracing",
 ]
 

--- a/example/start-axum/src/app.rs
+++ b/example/start-axum/src/app.rs
@@ -78,14 +78,14 @@ pub struct PostId(String);
 fn use_post_query(cx: Scope, post_id: PostId) -> QueryResult<String> {
     leptos_query::use_query(
         cx,
-        post_id,
+        move || post_id.clone(),
         |id| async move { get_post(id).await.unwrap() },
         QueryOptions {
             default_value: None,
-            refetch_interval: None,
+            refetch_interval: Some(Duration::from_secs(5)),
             resource_option: ResourceOption::NonBlocking,
-            stale_time: Some(Duration::from_secs(5)),
-            cache_time: Some(Duration::from_secs(30)),
+            stale_time: Some(Duration::from_secs(30)),
+            cache_time: Some(Duration::from_secs(60)),
         },
     )
 }

--- a/example/start-axum/src/app.rs
+++ b/example/start-axum/src/app.rs
@@ -91,10 +91,10 @@ fn use_post_query(cx: Scope, key: impl Fn() -> PostId + 'static) -> QueryResult<
         get_post_unwrapped,
         QueryOptions {
             default_value: None,
-            refetch_interval: Some(Duration::from_secs(5)),
+            refetch_interval: None,
             resource_option: ResourceOption::NonBlocking,
             stale_time: Some(Duration::from_secs(10)),
-            cache_time: Some(Duration::from_secs(20)),
+            cache_time: Some(Duration::from_secs(60)),
         },
     )
 }

--- a/example/start-axum/src/app.rs
+++ b/example/start-axum/src/app.rs
@@ -137,7 +137,7 @@ fn Post(cx: Scope, #[prop(into)] post_id: MaybeSignal<PostId>) -> impl IntoView 
     let QueryResult {
         data,
         is_loading,
-        is_refetching,
+        is_fetching,
         is_stale,
         ..
     } = query;
@@ -153,7 +153,7 @@ fn Post(cx: Scope, #[prop(into)] post_id: MaybeSignal<PostId>) -> impl IntoView 
             <div>
                 <span>"Fetching Status: "</span>
                 <span>
-                    {move || { if is_refetching.get() { "Fetching..." } else { "Idle" } }}
+                    {move || { if is_fetching.get() { "Fetching..." } else { "Idle" } }}
                 </span>
             </div>
             <div>

--- a/example/start-axum/src/main.rs
+++ b/example/start-axum/src/main.rs
@@ -7,7 +7,7 @@ async fn main() {
     use start_axum::app::*;
     use start_axum::fileserv::file_and_error_handler;
 
-    simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
+    simple_logger::init_with_level(log::Level::Info).expect("couldn't initialize logging");
 
     // Setting get_configuration(None) means we'll be using cargo-leptos's env values
     // For deployment these variables are:

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -3,8 +3,8 @@ use std::{
     time::Duration,
 };
 
-// Instant that can be used in both wasm and non-wasm environments.
-
+/// Instant that can be used in both wasm and non-wasm environments.
+/// Contains Duration since Unix Epoch (Unix Timestamp).
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct Instant(pub std::time::Duration);
 
@@ -27,7 +27,8 @@ impl Add<Instant> for Instant {
 
 pub fn get_instant() -> Instant {
     use cfg_if::cfg_if;
-    cfg_if! { if #[cfg(feature = "hydrate")] {
+    cfg_if! {
+        if #[cfg(feature = "hydrate")] {
             let millis = js_sys::Date::now();
             let duration = std::time::Duration::from_millis(millis as u64);
             Instant(duration)

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -28,14 +28,14 @@ impl Add<Instant> for Instant {
 pub fn get_instant() -> Instant {
     use cfg_if::cfg_if;
     cfg_if! { if #[cfg(feature = "hydrate")] {
-        let millis = js_sys::Date::now();
-        let duration = std::time::Duration::from_millis(millis as u64);
-        Instant(duration)
-    }}
-    cfg_if! { if #[cfg(not(feature = "hydrate"))] {
-        let duration = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .expect("System clock was before 1970.");
-        Instant(duration)
-    }}
+            let millis = js_sys::Date::now();
+            let duration = std::time::Duration::from_millis(millis as u64);
+            Instant(duration)
+        } else {
+            let duration = std::time::SystemTime::now()
+                .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .expect("System clock was before 1970.");
+            Instant(duration)
+        }
+    }
 }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -8,6 +8,13 @@ use std::{
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct Instant(pub std::time::Duration);
 
+impl Instant {
+    /// Get the current time as a Unix Timestamp.
+    pub fn now() -> Self {
+        get_instant()
+    }
+}
+
 impl Sub<Instant> for Instant {
     type Output = Duration;
 
@@ -25,7 +32,7 @@ impl Add<Instant> for Instant {
     }
 }
 
-pub fn get_instant() -> Instant {
+pub(crate) fn get_instant() -> Instant {
     use cfg_if::cfg_if;
     cfg_if! {
         if #[cfg(feature = "hydrate")] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! // Monkey fetcher.
 //! async fn get_monkey(id: MonkeyId) -> Monkey {
-//! ...
+//!     todo!()
 //! }
 //!
 //! // Query for a Monkey.
@@ -53,7 +53,7 @@
 //!     leptos_query::use_query(
 //!         cx,
 //!         id,
-//!         |id| async move { get_monkey(id).await },
+//!         get_monkey,
 //!         QueryOptions {
 //!             default_value: None,
 //!             refetch_interval: None,
@@ -71,7 +71,7 @@
 //!
 //! #[component]
 //! fn MonkeyView(cx: Scope, id: MonkeyId) -> impl IntoView {
-//!     let query = use_monkey_query(cx, id);
+//!     let query = use_monkey_query(cx, move || id.clone());
 //!     let QueryResult {
 //!         data,
 //!         is_loading,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //!     let QueryResult {
 //!         data,
 //!         is_loading,
-//!         is_refetching,
+//!         is_fetching,
 //!         is_stale
 //!         ..
 //!     } = query;
@@ -91,7 +91,7 @@
 //!            <div>
 //!                <span>"Fetching Status: "</span>
 //!                <span>
-//!                    {move || { if is_refetching.get() { "Fetching..." } else { "Idle" } }}
+//!                    {move || { if is_fetching.get() { "Fetching..." } else { "Idle" } }}
 //!                </span>
 //!            </div>
 //!            <div>
@@ -120,6 +120,7 @@
 
 mod instant;
 mod query_client;
+mod query_data;
 mod query_executor;
 mod query_options;
 mod query_result;
@@ -127,7 +128,9 @@ mod query_state;
 mod use_query;
 mod util;
 
+pub use instant::*;
 pub use query_client::*;
+pub use query_data::*;
 pub use query_options::*;
 pub use query_result::*;
 use query_state::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@
 
 mod instant;
 mod query_client;
+mod query_executor;
 mod query_options;
 mod query_result;
 mod query_state;

--- a/src/query_client.rs
+++ b/src/query_client.rs
@@ -1,4 +1,4 @@
-use crate::{QueryResult, QueryState};
+use crate::QueryState;
 use leptos::*;
 use std::{
     any::{Any, TypeId},

--- a/src/query_client.rs
+++ b/src/query_client.rs
@@ -1,4 +1,4 @@
-use crate::{QueryResult, QueryState};
+use crate::QueryState;
 use leptos::*;
 use std::{
     any::{Any, TypeId},
@@ -28,17 +28,17 @@ impl QueryClient {
     }
 
     /// Attempts to retrieve data for a query from the Query Cache.
-    pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
-    where
-        K: Hash + Eq + PartialEq + Clone + 'static,
-        V: Clone + 'static,
-    {
-        self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
-            cache
-                .get(key)
-                .map(|state| QueryResult::from_state(cx, state.clone()))
-        })
-    }
+    // pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
+    // where
+    //     K: Hash + Eq + PartialEq + Clone + 'static,
+    //     V: Clone + 'static,
+    // {
+    //     self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
+    //         cache
+    //             .get(key)
+    //             .map(|state| QueryResult::from_state(cx, state.clone()))
+    //     })
+    // }
 
     /// Attempts to invalidate an entry in the Query Cache.
     /// Returns true if the entry was successfully invalidated.

--- a/src/query_client.rs
+++ b/src/query_client.rs
@@ -1,4 +1,4 @@
-use crate::QueryState;
+use crate::{QueryResult, QueryState};
 use leptos::*;
 use std::{
     any::{Any, TypeId},
@@ -28,17 +28,17 @@ impl QueryClient {
     }
 
     /// Attempts to retrieve data for a query from the Query Cache.
-    // pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
-    // where
-    //     K: Hash + Eq + PartialEq + Clone + 'static,
-    //     V: Clone + 'static,
-    // {
-    //     self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
-    //         cache
-    //             .get(key)
-    //             .map(|state| QueryResult::from_state(cx, state.clone()))
-    //     })
-    // }
+    pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
+    where
+        K: Hash + Eq + PartialEq + Clone + 'static,
+        V: Clone + 'static,
+    {
+        self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
+            cache
+                .get(key)
+                .map(|state| QueryResult::from_state(cx, state.clone()))
+        })
+    }
 
     /// Attempts to invalidate an entry in the Query Cache.
     /// Returns true if the entry was successfully invalidated.

--- a/src/query_client.rs
+++ b/src/query_client.rs
@@ -73,12 +73,12 @@ impl QueryClient {
                 let cache = cache.borrow();
                 let invalidated = keys
                     .into_iter()
-                    .filter_map(|key| {
-                        if let Some(state) = cache.get(&key) {
+                    .filter(|key| {
+                        if let Some(state) = cache.get(key) {
                             state.invalidate();
-                            Some(key)
+                            true
                         } else {
-                            None
+                            false
                         }
                     })
                     .collect::<Vec<_>>();
@@ -119,8 +119,7 @@ where
 
     let cache = entry.or_insert_with(|| {
         let wrapped: CacheEntry<K, V> = Rc::new(RefCell::new(HashMap::new()));
-        let boxed = Box::new(wrapped) as Box<dyn Any>;
-        boxed
+        Box::new(wrapped) as Box<dyn Any>
     });
 
     let mut cache = cache

--- a/src/query_client.rs
+++ b/src/query_client.rs
@@ -28,17 +28,17 @@ impl QueryClient {
     }
 
     /// Attempts to retrieve data for a query from the Query Cache.
-    pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
-    where
-        K: Hash + Eq + PartialEq + Clone + 'static,
-        V: Clone + 'static,
-    {
-        self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
-            cache
-                .get(key)
-                .map(|state| QueryResult::from_state(cx, state.clone()))
-        })
-    }
+    // pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
+    // where
+    //     K: Hash + Eq + PartialEq + Clone + 'static,
+    //     V: Clone + 'static,
+    // {
+    //     self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
+    //         cache
+    //             .get(key)
+    //             .map(|state| QueryResult::from_state(cx, state.clone()))
+    //     })
+    // }
 
     /// Attempts to invalidate an entry in the Query Cache.
     /// Returns true if the entry was successfully invalidated.

--- a/src/query_client.rs
+++ b/src/query_client.rs
@@ -1,4 +1,4 @@
-use crate::QueryState;
+use crate::*;
 use leptos::*;
 use std::{
     any::{Any, TypeId},
@@ -33,17 +33,17 @@ impl QueryClient {
     }
 
     /// Attempts to retrieve data for a query from the Query Cache.
-    // pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryResult<V>>
-    // where
-    //     K: Hash + Eq + PartialEq + Clone + 'static,
-    //     V: Clone + 'static,
-    // {
-    //     self.use_cache(|cache: &HashMap<K, QueryState<K, V>>| {
-    //         cache
-    //             .get(key)
-    //             .map(|state| QueryResult::from_state(cx, state.clone()))
-    //     })
-    // }
+    pub fn get_query_data<K, V>(&self, cx: Scope, key: &K) -> Option<QueryData<V>>
+    where
+        K: Hash + Eq + PartialEq + Clone + 'static,
+        V: Clone + 'static,
+    {
+        self.use_cache_option(|cache: &HashMap<K, QueryState<K, V>>| {
+            cache
+                .get(key)
+                .map(|state| QueryData::from_state(cx, state.clone()))
+        })
+    }
 
     /// Attempts to invalidate an entry in the Query Cache.
     /// Returns true if the entry was successfully invalidated.

--- a/src/query_data.rs
+++ b/src/query_data.rs
@@ -1,0 +1,50 @@
+use leptos::*;
+
+use crate::*;
+
+/// Read only Query Data.
+/// Used when introspecting the query cache.
+#[derive(Clone)]
+pub struct QueryData<V>
+where
+    V: Clone + 'static,
+{
+    /// The current value of the query. None if it has not been fetched yet.
+    pub data: Signal<Option<V>>,
+    /// If the query is fetching for the first time.
+    pub is_loading: Signal<bool>,
+    /// If the query is currently fetching.
+    pub is_fetching: Signal<bool>,
+    /// If the query is considered stale.
+    pub is_stale: Signal<bool>,
+    /// The last time the query was updated. None if it has not been fetched yet.
+    pub updated_at: Signal<Option<Instant>>,
+    /// If the query should refetch on next usage.
+    pub invalidated: Signal<bool>,
+}
+
+impl<V> QueryData<V>
+where
+    V: Clone + 'static,
+{
+    pub(crate) fn from_state<K: Clone>(cx: Scope, state: QueryState<K, V>) -> Self {
+        let is_stale = create_rw_signal(cx, false);
+        let data = state.value.into();
+        let is_loading = state.fetching.into();
+        let is_fetching = state.fetching.into();
+        let is_stale = is_stale;
+        let updated_at = state.updated_at.into();
+        let invalidated = state.invalidated.into();
+
+        sync_stale_signal(cx, state, is_stale);
+
+        Self {
+            data,
+            is_loading,
+            is_fetching,
+            is_stale: is_stale.into(),
+            updated_at,
+            invalidated,
+        }
+    }
+}

--- a/src/query_executor.rs
+++ b/src/query_executor.rs
@@ -1,0 +1,210 @@
+use leptos::*;
+use std::{cell::Cell, future::Future, hash::Hash, rc::Rc, time::Duration};
+
+use crate::{
+    instant::{get_instant, Instant},
+    query_state::QueryState,
+    use_cache, use_query_client,
+    util::{time_until_stale, use_timeout},
+};
+
+type Refetch = Rc<dyn Fn() -> ()>;
+
+pub(crate) fn execute_query<K, V, Fu>(
+    cx: Scope,
+    state: Memo<QueryState<K, V>>,
+    query: impl Fn(K) -> Fu + 'static,
+    callback: impl Fn() -> () + 'static,
+) -> Refetch
+where
+    K: Clone + Hash + Eq + PartialEq + 'static,
+    V: Clone + 'static,
+    Fu: Future<Output = V> + 'static,
+{
+    let query = Rc::new(query);
+    let callback = Rc::new(callback);
+    let refetch = move || {
+        let query = query.clone();
+        let callback = callback.clone();
+        spawn_local(async move {
+            let state = state.get_untracked();
+            if !state.fetching.get_untracked() {
+                state.fetching.set(true);
+
+                let result = query(state.key.clone()).await;
+
+                state.updated_at.set(Some(get_instant()));
+                state.fetching.set(false);
+                state.value.set(Some(result.clone()));
+                if state.invalidated.get_untracked() {
+                    state.invalidated.set(false);
+                }
+                callback()
+            }
+        })
+    };
+
+    let refetch: Refetch = Rc::new(refetch);
+    ensure_not_stale(cx, state, refetch.clone());
+    sync_refetch(cx, state, refetch.clone());
+    sync_observers(cx, state);
+    // TODO FIX
+    ensure_cache_cleanup(cx, state, None);
+
+    refetch
+}
+
+fn ensure_not_stale<K: Clone, V: Clone>(
+    cx: Scope,
+    state: Memo<QueryState<K, V>>,
+    refetch: Refetch,
+) {
+    create_isomorphic_effect(cx, move |_| {
+        let state = state.get();
+        let updated_at = state.updated_at;
+        let stale_time = state.stale_time;
+
+        // On mount, ensure that the resource is not stale
+        match (updated_at.get_untracked(), stale_time.get_untracked()) {
+            (Some(updated_at), Some(stale_time)) => {
+                if time_until_stale(updated_at, stale_time).is_zero() {
+                    refetch();
+                }
+            }
+            _ => (),
+        }
+    })
+}
+
+fn sync_refetch<K, V>(cx: Scope, state: Memo<QueryState<K, V>>, refetch: Refetch)
+where
+    K: Clone + 'static,
+    V: Clone + 'static,
+{
+    create_isomorphic_effect(cx, {
+        let refetch = refetch.clone();
+        move |_| {
+            let refetch = refetch.clone();
+
+            let state = state.get();
+            let invalidated = state.invalidated;
+            let refetch_interval = state.refetch_interval;
+            let updated_at = state.updated_at;
+
+            // Effect for refetching query on interval.
+            use_timeout(cx, {
+                let refetch = refetch.clone();
+                move || match (updated_at.get(), refetch_interval.get()) {
+                    (Some(updated_at), Some(refetch_interval)) => {
+                        let refetch = refetch.clone();
+                        let timeout = time_until_stale(updated_at, refetch_interval);
+                        set_timeout_with_handle(
+                            move || {
+                                refetch();
+                            },
+                            timeout,
+                        )
+                        .ok()
+                    }
+                    _ => None,
+                }
+            });
+
+            // Refetch query if invalidated.
+            create_isomorphic_effect(cx, {
+                move |_| {
+                    if invalidated.get() {
+                        refetch();
+                    }
+                }
+            });
+        }
+    })
+}
+
+// Ensure that observers are kept track of.
+fn sync_observers<K: Clone, V: Clone>(cx: Scope, state: Memo<QueryState<K, V>>) {
+    type Observer = Rc<Cell<usize>>;
+    let last_observer: Rc<Cell<Option<Observer>>> = Rc::new(Cell::new(None));
+
+    on_cleanup(cx, {
+        let last_observer = last_observer.clone();
+        move || {
+            if let Some(observer) = last_observer.take() {
+                observer.set(observer.get() - 1);
+            }
+        }
+    });
+
+    // Ensure that observers are kept track of.
+    create_isomorphic_effect(cx, move |observers: Option<Rc<Cell<usize>>>| {
+        if let Some(observers) = observers {
+            last_observer.set(None);
+            observers.set(observers.get() - 1);
+        }
+        let observers = state.get().observers;
+        last_observer.set(Some(observers.clone()));
+        observers.set(observers.get() + 1);
+        observers
+    });
+}
+
+fn ensure_cache_cleanup<K, V>(
+    cx: Scope,
+    state: Memo<QueryState<K, V>>,
+    cache_time: Option<Duration>,
+) where
+    K: Clone + Hash + Eq + PartialEq + 'static,
+    V: Clone + 'static,
+{
+    let root_scope = use_query_client(cx).cx;
+    create_isomorphic_effect(cx, move |_| {
+        let state = state.get();
+        let key = state.key.clone();
+        let observers = state.observers.clone();
+        cache_cleanup::<K, V>(
+            root_scope,
+            key,
+            state.updated_at.into(),
+            cache_time,
+            observers,
+        );
+    });
+}
+
+// Will cleanup the cache corresponding to the key when the cache_time has elapsed, and the query has not been updated.
+fn cache_cleanup<K, V>(
+    cx: Scope,
+    key: K,
+    last_updated: Signal<Option<Instant>>,
+    cache_time: Option<Duration>,
+    observers: Rc<Cell<usize>>,
+) where
+    K: Hash + Eq + PartialEq + Clone + 'static,
+    V: 'static,
+{
+    use_timeout(cx, move || match (last_updated.get(), cache_time) {
+        (Some(last_updated), Some(cache_time)) => {
+            let timeout = time_until_stale(last_updated, cache_time);
+            let key = key.clone();
+            let observers = observers.clone();
+            set_timeout_with_handle(
+                move || {
+                    let removed =
+                        use_cache::<K, V, Option<QueryState<K, V>>>(cx, move |(_, cache)| {
+                            cache.remove(&key)
+                        });
+                    if let Some(query) = removed {
+                        if observers.get() == 0 {
+                            query.dispose();
+                            drop(query)
+                        }
+                    };
+                },
+                timeout,
+            )
+            .ok()
+        }
+        _ => None,
+    });
+}

--- a/src/query_executor.rs
+++ b/src/query_executor.rs
@@ -47,8 +47,7 @@ where
     ensure_not_stale(cx, state, executor.clone());
     sync_refetch(cx, state, executor.clone());
     sync_observers(cx, state);
-    // TODO FIX
-    ensure_cache_cleanup(cx, state, None);
+    ensure_cache_cleanup(cx, state);
 
     executor
 }
@@ -147,11 +146,8 @@ fn sync_observers<K: Clone, V: Clone>(cx: Scope, state: Memo<QueryState<K, V>>) 
     });
 }
 
-fn ensure_cache_cleanup<K, V>(
-    cx: Scope,
-    state: Memo<QueryState<K, V>>,
-    cache_time: Option<Duration>,
-) where
+fn ensure_cache_cleanup<K, V>(cx: Scope, state: Memo<QueryState<K, V>>)
+where
     K: Clone + Hash + Eq + PartialEq + 'static,
     V: Clone + 'static,
 {
@@ -164,7 +160,7 @@ fn ensure_cache_cleanup<K, V>(
             root_scope,
             key,
             state.updated_at.into(),
-            cache_time,
+            state.cache_time.get(),
             observers,
         );
     });

--- a/src/query_executor.rs
+++ b/src/query_executor.rs
@@ -16,7 +16,6 @@ pub(crate) fn create_executor<K, V, Fu>(
     cx: Scope,
     state: Memo<QueryState<K, V>>,
     query: impl Fn(K) -> Fu + 'static,
-    callback: impl Fn() + 'static,
 ) -> Executor
 where
     K: Clone + Hash + Eq + PartialEq + 'static,
@@ -24,10 +23,8 @@ where
     Fu: Future<Output = V> + 'static,
 {
     let query = Rc::new(query);
-    let callback = Rc::new(callback);
     let executor = move || {
         let query = query.clone();
-        let callback = callback.clone();
         spawn_local(async move {
             let state = state.get_untracked();
             if !state.fetching.get_untracked() {
@@ -41,7 +38,6 @@ where
                 if state.invalidated.get_untracked() {
                     state.invalidated.set(false);
                 }
-                callback()
             }
         })
     };

--- a/src/query_options.rs
+++ b/src/query_options.rs
@@ -13,11 +13,13 @@ pub struct QueryOptions<V> {
     /// Stale time is checked when [`QueryState::read`](#impl-<K,V>-for-QueryState<K,V>) is used.
     /// Stale time can never be greater than cache_time.
     /// Default is 0 milliseconds.
+    /// NOTE: If different stale times are used for the same key, the minimum time for the currently ACTIVE query will be used.
     pub stale_time: Option<Duration>,
     /// The amount of time a query will be cached, once it's considered stale.
     /// If no cache time, the query will never be revoked from cache.
     /// cache_time can never be less than stale_time.
     /// Default is 5 minutes.
+    /// NOTE: If different cache times are used for the same key, the minimum time will be used.
     pub cache_time: Option<Duration>,
     /// If no refetch interval, the query will never refetch.
     pub refetch_interval: Option<Duration>,

--- a/src/query_options.rs
+++ b/src/query_options.rs
@@ -65,12 +65,12 @@ pub(crate) fn ensure_valid_stale_time(
     match (stale_time, cache_time) {
         (Some(ref stale_time), Some(ref cache_time)) => {
             if stale_time > cache_time {
-                Some(cache_time.clone())
+                Some(*cache_time)
             } else {
-                Some(stale_time.clone())
+                Some(*stale_time)
             }
         }
-        (stale_time, _) => stale_time.clone(),
+        (stale_time, _) => *stale_time,
     }
 }
 

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -17,12 +17,14 @@ where
     pub data: Signal<Option<V>>,
     /// If the query is fetching for the first time.
     pub is_loading: Signal<bool>,
+    /// If the query is currently fetching.
+    pub is_fetching: Signal<bool>,
     /// If the query is considered stale.
     pub is_stale: Signal<bool>,
-    /// If the query is currently refetching.
-    pub is_refetching: Signal<bool>,
     /// The last time the query was updated. None if it has not been fetched yet.
     pub updated_at: Signal<Option<Instant>>,
+    /// If the query should refetch on next usage.
+    pub invalidated: Signal<bool>,
     /// Refetch the query.
     pub refetch: SignalSetter<()>,
 }
@@ -44,17 +46,19 @@ where
         is_loading: Signal<bool>,
         executor: Rc<dyn Fn()>,
     ) -> QueryResult<V> {
-        let is_stale = make_stale_signal(cx, state);
-        let is_refetching = Signal::derive(cx, move || state.get().fetching.get());
+        let is_stale = make_stale_signal_memo(cx, state);
+        let is_fetching = Signal::derive(cx, move || state.get().fetching.get());
         let updated_at = Signal::derive(cx, move || state.get().updated_at.get());
+        let invalidated = Signal::derive(cx, move || state.get().invalidated.get());
         let refetch = move |_: ()| executor();
 
         QueryResult {
             data,
             is_loading,
             is_stale,
-            is_refetching,
+            is_fetching,
             updated_at,
+            invalidated,
             refetch: refetch.mapped_signal_setter(cx),
         }
     }
@@ -62,33 +66,44 @@ where
 
 impl<V: Copy> Copy for QueryResult<V> where V: 'static {}
 
-fn make_stale_signal<K: Clone, V: Clone>(cx: Scope, state: Memo<QueryState<K, V>>) -> Signal<bool> {
-    let (stale, set_stale) = create_signal(cx, false);
+fn make_stale_signal_memo<K: Clone, V: Clone>(
+    cx: Scope,
+    state: Memo<QueryState<K, V>>,
+) -> Signal<bool> {
+    let stale = create_rw_signal(cx, false);
     create_isomorphic_effect(cx, move |_| {
         let state = state.get();
-        let updated_at = state.updated_at;
-        let stale_time = state.stale_time;
-
-        use_timeout(cx, move || match (updated_at.get(), stale_time.get()) {
-            (Some(updated_at), Some(stale_time)) => {
-                let timeout = time_until_stale(updated_at, stale_time);
-                if timeout.is_zero() {
-                    set_stale.set(true);
-                    None
-                } else {
-                    set_stale.set(false);
-                    set_timeout_with_handle(
-                        move || {
-                            set_stale.set(true);
-                        },
-                        timeout,
-                    )
-                    .ok()
-                }
-            }
-            _ => None,
-        })
+        sync_stale_signal(cx, state, stale)
     });
 
     stale.into()
+}
+
+pub(crate) fn sync_stale_signal<K: Clone, V: Clone>(
+    cx: Scope,
+    state: QueryState<K, V>,
+    stale: RwSignal<bool>,
+) {
+    let updated_at = state.updated_at;
+    let stale_time = state.stale_time;
+
+    use_timeout(cx, move || match (updated_at.get(), stale_time.get()) {
+        (Some(updated_at), Some(stale_time)) => {
+            let timeout = time_until_stale(updated_at, stale_time);
+            if timeout.is_zero() {
+                stale.set(true);
+                None
+            } else {
+                stale.set(false);
+                set_timeout_with_handle(
+                    move || {
+                        stale.set(true);
+                    },
+                    timeout,
+                )
+                .ok()
+            }
+        }
+        _ => None,
+    })
 }

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -42,7 +42,7 @@ where
         state: Memo<QueryState<K, V>>,
         data: Signal<Option<V>>,
         is_loading: Signal<bool>,
-        executor: Rc<dyn Fn() -> ()>,
+        executor: Rc<dyn Fn()>,
     ) -> QueryResult<V> {
         let is_stale = make_stale_signal(cx, state);
         let is_refetching = Signal::derive(cx, move || state.get().fetching.get());

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -1,4 +1,4 @@
-use crate::instant::Instant;
+use crate::{instant::Instant, query_state::QueryState};
 use leptos::*;
 
 /// Reactive query result.
@@ -33,14 +33,15 @@ where
 {
     pub(crate) fn from_state<K: Clone>(
         cx: Scope,
-        state: crate::QueryState<K, V>,
+        state: Signal<QueryState<K, V>>,
+        data: Signal<Option<V>>,
+        refetch: impl Fn() -> () + 'static,
     ) -> QueryResult<V> {
-        let data = state.read(cx);
-        let is_loading = state.is_loading(cx);
-        let is_refetching = state.is_refetching(cx);
-        let is_stale = state.is_stale(cx);
-        let updated_at = state.updated_at.clone().into();
-        let refetch = move |_: ()| state.refetch();
+        let is_loading = state.with(|s| s.is_loading(cx));
+        let is_stale = state.with(|s| s.is_stale(cx));
+        let is_refetching = state.with(|s| s.fetching.into());
+        let updated_at = state.with(|s| s.updated_at).into();
+        let refetch = move |_: ()| refetch();
 
         QueryResult {
             data,

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -42,12 +42,12 @@ where
         state: Memo<QueryState<K, V>>,
         data: Signal<Option<V>>,
         is_loading: Signal<bool>,
-        refetch: Rc<dyn Fn() -> ()>,
+        executor: Rc<dyn Fn() -> ()>,
     ) -> QueryResult<V> {
         let is_stale = make_stale_signal(cx, state);
         let is_refetching = Signal::derive(cx, move || state.get().fetching.get());
         let updated_at = Signal::derive(cx, move || state.get().updated_at.get());
-        let refetch = move |_: ()| refetch();
+        let refetch = move |_: ()| executor();
 
         QueryResult {
             data,

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -41,9 +41,9 @@ where
         cx: Scope,
         state: Memo<QueryState<K, V>>,
         data: Signal<Option<V>>,
+        is_loading: Signal<bool>,
         refetch: Rc<dyn Fn() -> ()>,
     ) -> QueryResult<V> {
-        let is_loading = Signal::derive(cx, move || state.get().is_loading(cx).get());
         let is_stale = make_stale_signal(cx, state);
         let is_refetching = Signal::derive(cx, move || state.get().fetching.get());
         let updated_at = Signal::derive(cx, move || state.get().updated_at.get());

--- a/src/query_result.rs
+++ b/src/query_result.rs
@@ -45,7 +45,10 @@ where
         let is_stale = make_stale_signal(cx, state);
         let is_refetching = Signal::derive(cx, move || state.get().fetching.get());
         let updated_at = Signal::derive(cx, move || state.get().updated_at.get());
-        let refetch = move |_: ()| resource.refetch();
+        let refetch = move |_: ()| {
+            state.get().needs_refetch.set(true);
+            resource.refetch()
+        };
 
         QueryResult {
             data,

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -11,7 +11,6 @@ where
 {
     pub(crate) key: K,
     pub(crate) observers: Rc<Cell<usize>>,
-    pub(crate) needs_refetch: Rc<Cell<bool>>,
     pub(crate) value: RwSignal<Option<V>>,
     pub(crate) stale_time: RwSignal<Option<Duration>>,
     pub(crate) refetch_interval: RwSignal<Option<Duration>>,
@@ -45,7 +44,6 @@ where
         QueryState {
             key,
             observers: Rc::new(Cell::new(0)),
-            needs_refetch: Rc::new(Cell::new(true)),
             value,
             stale_time,
             refetch_interval,
@@ -77,6 +75,10 @@ where
 
     pub(crate) fn is_loading_untracked(&self) -> bool {
         self.updated_at.get_untracked().is_none() && self.fetching.get_untracked()
+    }
+
+    pub(crate) fn needs_init(&self) -> bool {
+        self.updated_at.get_untracked().is_none() && !self.fetching.get_untracked()
     }
 
     // Enables having different stale times & refetch intervals for the same query.

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -1,11 +1,11 @@
 use leptos::*;
-use std::{cell::Cell, future::Future, rc::Rc, time::Duration};
+use std::{cell::Cell, rc::Rc, time::Duration};
 
 use crate::{
     ensure_valid_stale_time,
-    instant::{get_instant, Instant},
+    instant::Instant,
     util::{time_until_stale, use_timeout},
-    QueryOptions, ResourceOption,
+    QueryOptions,
 };
 
 #[derive(Clone)]
@@ -14,77 +14,41 @@ where
     K: 'static,
     V: 'static,
 {
-    pub(crate) observers: Rc<Cell<usize>>,
-    #[allow(dead_code)]
     pub(crate) key: K,
-    pub(crate) resource: RwSignal<Resource<(), V>>,
+    pub(crate) observers: Rc<Cell<usize>>,
+    pub(crate) value: RwSignal<Option<V>>,
     pub(crate) stale_time: RwSignal<Option<Duration>>,
     pub(crate) refetch_interval: RwSignal<Option<Duration>>,
     pub(crate) updated_at: RwSignal<Option<Instant>>,
     pub(crate) invalidated: RwSignal<bool>,
+    pub(crate) fetching: RwSignal<bool>,
 }
+
+impl<K: PartialEq, V> PartialEq for QueryState<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl<K: PartialEq, V> Eq for QueryState<K, V> {}
 
 impl<K, V> QueryState<K, V>
 where
     K: Clone + 'static,
     V: Clone + Serializable + 'static,
 {
-    pub(crate) fn new<Fu>(
-        scope: Scope,
-        key: K,
-        fetcher: impl Fn(K) -> Fu + 'static,
-        options: QueryOptions<V>,
-    ) -> Self
-    where
-        Fu: Future<Output = V> + 'static,
-    {
-        let fetcher = Rc::new(fetcher);
-        let updated_at: RwSignal<Option<Instant>> = create_rw_signal(scope, None);
-
-        let key = key.clone();
-        let fetcher = {
-            let fetcher = fetcher.clone();
-            let key = key.clone();
-            move |_: ()| {
-                let fetcher = fetcher.clone();
-                let key = key.clone();
-                async move {
-                    let result = fetcher(key).await;
-                    let instant = get_instant();
-                    updated_at.set(Some(instant));
-                    result
-                }
-            }
-        };
-
-        let QueryOptions {
-            default_value,
-            ref resource_option,
-            refetch_interval,
-            ref stale_time,
-            ref cache_time,
-            ..
-        } = options;
-
-        let resource = {
-            match resource_option {
-                ResourceOption::NonBlocking => {
-                    create_resource_with_initial_value(scope, || (), fetcher, default_value)
-                }
-                ResourceOption::Blocking => create_blocking_resource(scope, || (), fetcher),
-            }
-        };
-
-        let stale_time = ensure_valid_stale_time(stale_time, cache_time);
+    pub(crate) fn new(cx: Scope, key: K, options: QueryOptions<V>) -> Self {
+        let stale_time = ensure_valid_stale_time(&options.stale_time, &options.cache_time);
 
         QueryState {
+            key,
             observers: Rc::new(Cell::new(0)),
-            key: key.clone(),
-            resource: create_rw_signal(scope, resource),
-            stale_time: create_rw_signal(scope, stale_time),
-            refetch_interval: create_rw_signal(scope, refetch_interval),
-            updated_at,
-            invalidated: create_rw_signal(scope, false),
+            value: create_rw_signal(cx, None),
+            stale_time: create_rw_signal(cx, stale_time),
+            refetch_interval: create_rw_signal(cx, options.refetch_interval),
+            updated_at: create_rw_signal(cx, None),
+            invalidated: create_rw_signal(cx, false),
+            fetching: create_rw_signal(cx, false),
         }
     }
 }
@@ -94,24 +58,9 @@ where
     K: Clone + 'static,
     V: Clone + 'static,
 {
-    pub(crate) fn refetch(&self) {
-        let resource = self.resource.get();
-        if !resource.loading().get() {
-            resource.refetch();
-            self.invalidated.set(false);
-        }
-    }
-
     /// Marks the resource as invalidated, which will cause it to be refetched on next read.
     pub(crate) fn invalidate(&self) {
         self.invalidated.set(true);
-    }
-
-    /// If the query is currently being fetched in the background.
-    pub(crate) fn is_refetching(&self, cx: Scope) -> Signal<bool> {
-        let resource = self.resource;
-
-        Signal::derive(cx, move || resource.get().loading().get())
     }
 
     pub(crate) fn is_stale(&self, cx: Scope) -> Signal<bool> {
@@ -142,10 +91,9 @@ where
     /// IMPORTANT: If the query is never [read](QueryState::read), this will always return false.
     pub(crate) fn is_loading(&self, cx: Scope) -> Signal<bool> {
         let updated_at = self.updated_at;
-        let is_loading = self.resource;
-        Signal::derive(cx, move || {
-            updated_at.get().is_none() && is_loading.get().loading().get()
-        })
+        let fetching = self.fetching;
+
+        Signal::derive(cx, move || updated_at.get().is_none() && fetching.get())
     }
 
     pub(crate) fn set_options(&self, cx: Scope, options: QueryOptions<V>) {
@@ -185,80 +133,15 @@ where
             }
         })
     }
-
-    pub(crate) fn read(&self, cx: Scope) -> Signal<Option<V>> {
-        let invalidated = self.invalidated;
-        let refetch_interval = self.refetch_interval;
-        let resource = self.resource;
-        let stale_time = self.stale_time;
-        let updated_at = self.updated_at;
-
-        let refetch = move || {
-            if updated_at.get_untracked().is_some() {
-                let resource = resource.get_untracked();
-                if !resource.loading().get_untracked() {
-                    resource.refetch();
-                    invalidated.set(false);
-                }
-            }
-        };
-        let refetch = store_value(cx, refetch);
-
-        // Effect for refetching query on interval.
-        use_timeout(cx, move || {
-            match (updated_at.get(), refetch_interval.get()) {
-                (Some(updated_at), Some(refetch_interval)) => {
-                    let timeout = time_until_stale(updated_at, refetch_interval);
-                    set_timeout_with_handle(
-                        move || {
-                            refetch.with_value(|r| r());
-                        },
-                        timeout,
-                    )
-                    .ok()
-                }
-                _ => None,
-            }
-        });
-
-        // Refetch query if invalidated.
-        create_effect(cx, {
-            move |_| {
-                if invalidated.get() {
-                    refetch.with_value(|r| r());
-                }
-            }
-        });
-
-        Signal::derive(cx, move || {
-            // On mount, ensure that the resource is not stale
-            match (updated_at.get_untracked(), stale_time.get_untracked()) {
-                (Some(updated_at), Some(stale_time)) => {
-                    if time_until_stale(updated_at, stale_time).is_zero() {
-                        refetch.with_value(|r| r());
-                    }
-                }
-                _ => (),
-            }
-
-            // Happens when the resource is SSR'd.
-            let read = resource.get().read(cx);
-            if read.is_some() && updated_at.get_untracked().is_none() {
-                updated_at.set(Some(get_instant()));
-            }
-
-            read
-        })
-    }
 }
 
 impl<K, V> QueryState<K, V> {
     pub(crate) fn dispose(&self) {
-        // TODO: Dispose Resource with runtime.
-        self.resource.dispose();
+        self.value.dispose();
         self.stale_time.dispose();
         self.refetch_interval.dispose();
         self.updated_at.dispose();
         self.invalidated.dispose();
+        self.fetching.dispose();
     }
 }

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -127,8 +127,9 @@ impl<K, V> QueryState<K, V> {
         self.value.dispose();
         self.stale_time.dispose();
         self.refetch_interval.dispose();
+        self.fetching.dispose();
+        self.cache_time.dispose();
         self.updated_at.dispose();
         self.invalidated.dispose();
-        self.fetching.dispose();
     }
 }

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -64,12 +64,9 @@ where
         self.invalidated.set(true);
     }
 
-    pub(crate) fn is_loading_untracked(&self) -> bool {
-        self.updated_at.get_untracked().is_none() && self.fetching.get_untracked()
-    }
-
     pub(crate) fn needs_init(&self) -> bool {
-        self.updated_at.get_untracked().is_none() && !self.fetching.get_untracked()
+        (self.value.get_untracked().is_none() || self.updated_at.get_untracked().is_none())
+            && !self.fetching.get_untracked()
     }
 
     // Enables having different stale times & refetch intervals for the same query.

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -1,12 +1,7 @@
 use leptos::*;
 use std::{cell::Cell, rc::Rc, time::Duration};
 
-use crate::{
-    ensure_valid_stale_time,
-    instant::Instant,
-    util::{time_until_stale, use_timeout},
-    QueryOptions,
-};
+use crate::{ensure_valid_stale_time, instant::Instant, QueryOptions};
 
 #[derive(Clone)]
 pub(crate) struct QueryState<K, V>
@@ -16,6 +11,7 @@ where
 {
     pub(crate) key: K,
     pub(crate) observers: Rc<Cell<usize>>,
+    pub(crate) needs_refetch: Rc<Cell<bool>>,
     pub(crate) value: RwSignal<Option<V>>,
     pub(crate) stale_time: RwSignal<Option<Duration>>,
     pub(crate) refetch_interval: RwSignal<Option<Duration>>,
@@ -49,6 +45,7 @@ where
         QueryState {
             key,
             observers: Rc::new(Cell::new(0)),
+            needs_refetch: Rc::new(Cell::new(true)),
             value,
             stale_time,
             refetch_interval,

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -64,15 +64,6 @@ where
         self.invalidated.set(true);
     }
 
-    /// If the query is being fetched for the first time.
-    /// IMPORTANT: If the query is never [read](QueryState::read), this will always return false.
-    pub(crate) fn is_loading(&self, cx: Scope) -> Signal<bool> {
-        let updated_at = self.updated_at;
-        let fetching = self.fetching;
-
-        Signal::derive(cx, move || updated_at.get().is_none() && fetching.get())
-    }
-
     pub(crate) fn is_loading_untracked(&self) -> bool {
         self.updated_at.get_untracked().is_none() && self.fetching.get_untracked()
     }

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -1,11 +1,11 @@
 use leptos::*;
-use std::{cell::Cell, rc::Rc, time::Duration};
+use std::{cell::Cell, future::Future, rc::Rc, time::Duration};
 
 use crate::{
     ensure_valid_stale_time,
-    instant::Instant,
+    instant::{get_instant, Instant},
     util::{time_until_stale, use_timeout},
-    QueryOptions,
+    QueryOptions, ResourceOption,
 };
 
 #[derive(Clone)]
@@ -15,6 +15,7 @@ where
     V: 'static,
 {
     pub(crate) key: K,
+    pub(crate) resource: Resource<(), V>,
     pub(crate) observers: Rc<Cell<usize>>,
     pub(crate) value: RwSignal<Option<V>>,
     pub(crate) stale_time: RwSignal<Option<Duration>>,
@@ -37,18 +38,64 @@ where
     K: Clone + 'static,
     V: Clone + Serializable + 'static,
 {
-    pub(crate) fn new(cx: Scope, key: K, options: QueryOptions<V>) -> Self {
+    pub(crate) fn new<Fu>(
+        cx: Scope,
+        key: K,
+        query: Rc<impl Fn(K) -> Fu + 'static>,
+        options: QueryOptions<V>,
+    ) -> Self
+    where
+        Fu: Future<Output = V> + 'static,
+    {
         let stale_time = ensure_valid_stale_time(&options.stale_time, &options.cache_time);
+        let stale_time = create_rw_signal(cx, stale_time);
+        let refetch_interval = create_rw_signal(cx, options.refetch_interval);
+
+        let value = create_rw_signal(cx, None);
+        let updated_at = create_rw_signal(cx, None);
+        let invalidated = create_rw_signal(cx, false);
+        let fetching = create_rw_signal(cx, false);
+
+        let fetcher = {
+            let key = key.clone();
+            move |_: ()| {
+                let key = key.clone();
+                let query = query.clone();
+                async move {
+                    fetching.set(true);
+                    let result = query(key).await;
+                    updated_at.set(Some(get_instant()));
+                    fetching.set(false);
+                    value.set(Some(result.clone()));
+                    result
+                }
+            }
+        };
+        let QueryOptions {
+            default_value,
+            ref resource_option,
+            ..
+        } = options;
+
+        let resource = {
+            match resource_option {
+                ResourceOption::NonBlocking => {
+                    create_resource_with_initial_value(cx, || (), fetcher, default_value)
+                }
+                ResourceOption::Blocking => create_blocking_resource(cx, || (), fetcher),
+            }
+        };
 
         QueryState {
             key,
+            resource,
             observers: Rc::new(Cell::new(0)),
-            value: create_rw_signal(cx, None),
-            stale_time: create_rw_signal(cx, stale_time),
-            refetch_interval: create_rw_signal(cx, options.refetch_interval),
-            updated_at: create_rw_signal(cx, None),
-            invalidated: create_rw_signal(cx, false),
-            fetching: create_rw_signal(cx, false),
+            value,
+            stale_time,
+            refetch_interval,
+            updated_at,
+            invalidated,
+            fetching,
         }
     }
 }
@@ -61,6 +108,15 @@ where
     /// Marks the resource as invalidated, which will cause it to be refetched on next read.
     pub(crate) fn invalidate(&self) {
         self.invalidated.set(true);
+    }
+
+    pub(crate) fn refetch(&self) {
+        if self.updated_at.get_untracked().is_some() {
+            if !self.resource.loading().get_untracked() {
+                self.resource.refetch();
+                self.invalidated.set(false);
+            }
+        }
     }
 
     pub(crate) fn is_stale(&self, cx: Scope) -> Signal<bool> {
@@ -97,8 +153,8 @@ where
     }
 
     pub(crate) fn set_options(&self, cx: Scope, options: QueryOptions<V>) {
-        let curr_stale = self.stale_time.get();
-        let curr_refetch_interval = self.refetch_interval.get();
+        let curr_stale = self.stale_time.get_untracked();
+        let curr_refetch_interval = self.refetch_interval.get_untracked();
 
         let (prev_stale, new_stale) = match (curr_stale, options.stale_time) {
             (Some(current), Some(new)) if current > new => (Some(current), Some(new)),
@@ -131,6 +187,70 @@ where
             if let Some(prev_refetch) = prev_refetch {
                 refetch_interval.set(Some(prev_refetch));
             }
+        })
+    }
+
+    pub(crate) fn read(&self, cx: Scope) -> Signal<Option<V>> {
+        let invalidated = self.invalidated;
+        let refetch_interval = self.refetch_interval;
+        let resource = self.resource;
+        let stale_time = self.stale_time;
+        let updated_at = self.updated_at;
+
+        let refetch = move || {
+            if updated_at.get_untracked().is_some() {
+                if !resource.loading().get_untracked() {
+                    resource.refetch();
+                    invalidated.set(false);
+                }
+            }
+        };
+        let refetch = store_value(cx, refetch);
+
+        // Effect for refetching query on interval.
+        use_timeout(cx, move || {
+            match (updated_at.get(), refetch_interval.get()) {
+                (Some(updated_at), Some(refetch_interval)) => {
+                    let timeout = time_until_stale(updated_at, refetch_interval);
+                    set_timeout_with_handle(
+                        move || {
+                            refetch.with_value(|r| r());
+                        },
+                        timeout,
+                    )
+                    .ok()
+                }
+                _ => None,
+            }
+        });
+
+        // Refetch query if invalidated.
+        create_effect(cx, {
+            move |_| {
+                if invalidated.get() {
+                    refetch.with_value(|r| r());
+                }
+            }
+        });
+
+        Signal::derive(cx, move || {
+            // On mount, ensure that the resource is not stale
+            match (updated_at.get_untracked(), stale_time.get_untracked()) {
+                (Some(updated_at), Some(stale_time)) => {
+                    if time_until_stale(updated_at, stale_time).is_zero() {
+                        refetch.with_value(|r| r());
+                    }
+                }
+                _ => (),
+            }
+
+            // Happens when the resource is SSR'd.
+            let read = resource.read(cx);
+            if read.is_some() && updated_at.get_untracked().is_none() {
+                updated_at.set(Some(get_instant()));
+            }
+
+            read
         })
     }
 }

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -1,11 +1,11 @@
 use leptos::*;
-use std::{cell::Cell, future::Future, rc::Rc, time::Duration};
+use std::{cell::Cell, rc::Rc, time::Duration};
 
 use crate::{
     ensure_valid_stale_time,
-    instant::{get_instant, Instant},
+    instant::Instant,
     util::{time_until_stale, use_timeout},
-    QueryOptions, ResourceOption,
+    QueryOptions,
 };
 
 #[derive(Clone)]
@@ -15,7 +15,6 @@ where
     V: 'static,
 {
     pub(crate) key: K,
-    pub(crate) resource: Resource<(), V>,
     pub(crate) observers: Rc<Cell<usize>>,
     pub(crate) value: RwSignal<Option<V>>,
     pub(crate) stale_time: RwSignal<Option<Duration>>,
@@ -38,57 +37,17 @@ where
     K: Clone + 'static,
     V: Clone + Serializable + 'static,
 {
-    pub(crate) fn new<Fu>(
-        cx: Scope,
-        key: K,
-        query: Rc<impl Fn(K) -> Fu + 'static>,
-        options: QueryOptions<V>,
-    ) -> Self
-    where
-        Fu: Future<Output = V> + 'static,
-    {
+    pub(crate) fn new(cx: Scope, key: K, options: QueryOptions<V>) -> Self {
         let stale_time = ensure_valid_stale_time(&options.stale_time, &options.cache_time);
         let stale_time = create_rw_signal(cx, stale_time);
         let refetch_interval = create_rw_signal(cx, options.refetch_interval);
-
         let value = create_rw_signal(cx, None);
         let updated_at = create_rw_signal(cx, None);
         let invalidated = create_rw_signal(cx, false);
         let fetching = create_rw_signal(cx, false);
 
-        let fetcher = {
-            let key = key.clone();
-            move |_: ()| {
-                let key = key.clone();
-                let query = query.clone();
-                async move {
-                    fetching.set(true);
-                    let result = query(key).await;
-                    updated_at.set(Some(get_instant()));
-                    fetching.set(false);
-                    value.set(Some(result.clone()));
-                    result
-                }
-            }
-        };
-        let QueryOptions {
-            default_value,
-            ref resource_option,
-            ..
-        } = options;
-
-        let resource = {
-            match resource_option {
-                ResourceOption::NonBlocking => {
-                    create_resource_with_initial_value(cx, || (), fetcher, default_value)
-                }
-                ResourceOption::Blocking => create_blocking_resource(cx, || (), fetcher),
-            }
-        };
-
         QueryState {
             key,
-            resource,
             observers: Rc::new(Cell::new(0)),
             value,
             stale_time,
@@ -110,39 +69,6 @@ where
         self.invalidated.set(true);
     }
 
-    pub(crate) fn refetch(&self) {
-        if self.updated_at.get_untracked().is_some() {
-            if !self.resource.loading().get_untracked() {
-                self.resource.refetch();
-                self.invalidated.set(false);
-            }
-        }
-    }
-
-    pub(crate) fn is_stale(&self, cx: Scope) -> Signal<bool> {
-        let updated_at = self.updated_at;
-        let stale_time = self.stale_time;
-        let (stale, set_stale) = create_signal(cx, false);
-        use_timeout(cx, move || match (updated_at.get(), stale_time.get()) {
-            (Some(updated_at), Some(stale_time)) => {
-                let timeout = time_until_stale(updated_at, stale_time);
-                if !timeout.is_zero() {
-                    set_stale.set(false);
-                }
-                set_timeout_with_handle(
-                    move || {
-                        set_stale.set(true);
-                    },
-                    timeout,
-                )
-                .ok()
-            }
-            _ => None,
-        });
-
-        stale.into()
-    }
-
     /// If the query is being fetched for the first time.
     /// IMPORTANT: If the query is never [read](QueryState::read), this will always return false.
     pub(crate) fn is_loading(&self, cx: Scope) -> Signal<bool> {
@@ -150,6 +76,10 @@ where
         let fetching = self.fetching;
 
         Signal::derive(cx, move || updated_at.get().is_none() && fetching.get())
+    }
+
+    pub(crate) fn is_loading_untracked(&self) -> bool {
+        self.updated_at.get_untracked().is_none() && self.fetching.get_untracked()
     }
 
     // Enables having different stale times & refetch intervals for the same query.
@@ -191,34 +121,6 @@ where
                 refetch_interval.set(Some(prev_refetch));
             }
         })
-    }
-
-    pub(crate) fn read(&self, cx: Scope) -> Option<V> {
-        let updated_at = self.updated_at;
-        let stale_time = self.stale_time;
-        let resource = self.resource;
-        let invalidated = self.invalidated;
-
-        let fetching = self.fetching;
-
-        // On mount, ensure that the resource is not stale
-        match (updated_at.get_untracked(), stale_time.get_untracked()) {
-            (Some(updated_at), Some(stale_time)) => {
-                if time_until_stale(updated_at, stale_time).is_zero() && !fetching.get_untracked() {
-                    resource.refetch();
-                    invalidated.set(false);
-                }
-            }
-            _ => (),
-        }
-
-        // Happens when the resource is SSR'd.
-        let read = resource.read(cx);
-        if read.is_some() && updated_at.get_untracked().is_none() {
-            updated_at.set(Some(get_instant()));
-        }
-
-        read
     }
 }
 

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -116,7 +116,7 @@ where
         }
     };
 
-    let resource = {
+    let resource: Resource<QueryState<K, V>, Option<V>> = {
         match options.resource_option {
             ResourceOption::NonBlocking => create_resource(cx, move || state.get(), fetcher),
             ResourceOption::Blocking => create_blocking_resource(cx, move || state.get(), fetcher),
@@ -141,7 +141,6 @@ where
         }
     });
 
-    // When key changes.
     let data = Signal::derive(cx, move || resource.read(cx).flatten());
 
     let is_loading = Signal::derive(cx, move || {

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -39,7 +39,7 @@ pub fn provide_query_client(cx: Scope) {
 ///
 /// // Monkey fetcher.
 /// async fn get_monkey(id: MonkeyId) -> Monkey {
-/// ...
+///     todo!()
 /// }
 ///
 /// // Query for a Monkey.

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -1,25 +1,15 @@
-use crate::instant::{get_instant, Instant};
+use crate::query_executor::execute_query;
 use crate::query_result::QueryResult;
-use crate::util::{time_until_stale, use_timeout};
-use crate::{CacheEntry, QueryClient, QueryOptions, QueryState, ResourceOption};
+use crate::{use_cache, QueryClient, QueryOptions, QueryState, ResourceOption};
 use leptos::*;
-use std::any::{Any, TypeId};
-use std::cell::{Cell, RefCell};
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::future::Future;
 use std::hash::Hash;
-use std::rc::Rc;
 use std::time::Duration;
 
 /// Provides a Query Client to the current scope.
 pub fn provide_query_client(cx: Scope) {
     provide_context(cx, QueryClient::new(cx));
-}
-
-/// Retrieves a Query Client from the current scope.
-pub fn use_query_client(cx: Scope) -> QueryClient {
-    use_context::<QueryClient>(cx).expect("Query Client Missing.")
 }
 
 /// Creates a query. Useful for data fetching, caching, and synchronization with server state.
@@ -76,13 +66,13 @@ pub fn use_query<K, V, Fu>(
     options: QueryOptions<V>,
 ) -> QueryResult<V>
 where
-    Fu: Future<Output = V> + 'static,
     K: Hash + Eq + PartialEq + Clone + 'static,
     V: Clone
         + Serializable
         + 'static
         + server_fn::serde::de::DeserializeOwned
         + server_fn::serde::Serialize,
+    Fu: Future<Output = V> + 'static,
 {
     let key = create_memo(cx, move |_| key());
 
@@ -114,266 +104,47 @@ where
         }
     });
 
-    let query = Rc::new(query);
-    let fetcher = move |key: K| {
-        let query = query.clone();
+    let fetcher = move |state: QueryState<K, V>| {
         async move {
-            let state = state.get_untracked();
-            if state.is_loading_untracked() {
+            if state.value.get_untracked().is_none() || state.is_loading_untracked() {
                 // Suspend indefinitely and wait for interruption.
-                log!("SUSPENDING");
                 gloo_timers::future::sleep(LONG_TIME).await;
-                state.value.get_untracked()
-            // Ensure no request in flight.
-            // Need to ensure that refetch was actually called as well.
-            // TODO: here we only want to fetch the very first time???????
-            } else if !(state.fetching.get_untracked()) && state.needs_refetch.get() {
-                log!(
-                    "NEEDS REFETCH. fetching: {}, needs: {}",
-                    state.fetching.get_untracked(),
-                    state.needs_refetch.get()
-                );
-                state.fetching.set(true);
-                let result = query(key).await;
-                state.updated_at.set(Some(get_instant()));
-                state.fetching.set(false);
-                state.value.set(Some(result.clone()));
-                state.needs_refetch.set(false);
-                if state.invalidated.get_untracked() {
-                    state.invalidated.set(false);
-                }
-                return Some(result);
+                None
             } else {
-                log!("USING STATE VALUE!");
                 state.value.get_untracked()
             }
         }
     };
 
-    let resource: Resource<K, Option<V>> = {
+    let resource = {
         match options.resource_option {
-            ResourceOption::NonBlocking => create_resource(cx, move || key.get(), fetcher),
-            ResourceOption::Blocking => create_blocking_resource(cx, move || key.get(), fetcher),
+            ResourceOption::NonBlocking => create_resource(cx, move || state.get(), fetcher),
+            ResourceOption::Blocking => create_blocking_resource(cx, move || state.get(), fetcher),
         }
     };
 
-    // Listen for changes to the same key.
-    create_isomorphic_effect(cx, move |prev_key: Option<K>| {
-        let state = state.get();
-        let data = state.value.get();
+    let callback = move || resource.refetch();
+    let refetch = execute_query(cx, state, query, callback);
 
-        if let Some(prev_key) = prev_key {
-            if state.key == prev_key && data.is_some() {
-                resource.set(data);
+    create_isomorphic_effect(cx, {
+        let refetch = refetch.clone();
+        move |_| {
+            let state = state.get();
+            let value = state.value.get();
+            // Fetch for first time if necessary.
+            if state.needs_init() {
+                refetch();
+            // Update resource with latest value.
+            } else if value.is_some() {
+                resource.set(value);
             }
-            // This is breaking something. Need to check that resource hasn't been initialized.
-            // This needs to happen when requests are duplicated?
         }
-        // else if data.is_some() {
-        //     log!("SETTING RESOURCE DIRECTLY");
-        //     resource.set(data);
-        // }
-        state.key.clone()
     });
 
     // When key changes.
-    create_isomorphic_effect(cx, move |prev_key: Option<K>| {
-        let state = state.get();
-        let data = state.value.get();
+    let data = Signal::derive(cx, move || resource.read(cx).flatten());
 
-        if let Some(prev_key) = prev_key {
-            if state.key != prev_key && data.is_some() {
-                resource.set(data);
-            }
-            // TODO: If key changes, and new data isn't loaded, then loading should appear again?
-            // RE TRIGGER SUSPENSE.
-        }
-        state.key.clone()
-    });
-
-    ensure_not_stale(cx, state.clone(), resource.clone());
-    sync_refetch(cx, state.clone(), resource.clone());
-    sync_observers(cx, state.clone());
-
-    // Ensure that the Query is removed from cache up after the specified cache_time.
-    let root_scope = use_query_client(cx).cx;
-    let cache_time = options.cache_time;
-    create_isomorphic_effect(cx, move |_| {
-        let state = state.get();
-        let observers = state.observers.clone();
-        let key = key.get();
-        cache_cleanup::<K, V>(
-            root_scope,
-            key,
-            state.updated_at.into(),
-            cache_time,
-            observers,
-        );
-    });
-
-    QueryResult::new(cx, state, resource)
+    QueryResult::new(cx, state, data, refetch)
 }
 
 const LONG_TIME: Duration = Duration::from_secs(60 * 60 * 24);
-
-// When two things are stale, then the second will be refetched.
-fn ensure_not_stale<K: Clone, V: Clone>(
-    cx: Scope,
-    state: Memo<QueryState<K, V>>,
-    resource: Resource<K, Option<V>>,
-) {
-    create_isomorphic_effect(cx, move |_| {
-        let state = state.get();
-        let updated_at = state.updated_at;
-        let stale_time = state.stale_time;
-
-        // On mount, ensure that the resource is not stale
-        match (updated_at.get_untracked(), stale_time.get_untracked()) {
-            (Some(updated_at), Some(stale_time)) => {
-                if time_until_stale(updated_at, stale_time).is_zero() && !state.needs_refetch.get()
-                {
-                    log!("STALE!! Refetching");
-                    state.needs_refetch.set(true);
-                    resource.refetch();
-                }
-            }
-            _ => (),
-        }
-    })
-}
-
-// Effects for syncing on interval and invalidation.
-fn sync_refetch<K, V>(cx: Scope, state: Memo<QueryState<K, V>>, resource: Resource<K, Option<V>>)
-where
-    K: Clone + 'static,
-    V: Clone + 'static,
-{
-    create_isomorphic_effect(cx, move |_| {
-        let state = state.get();
-        let invalidated = state.invalidated;
-        let refetch_interval = state.refetch_interval;
-        let updated_at = state.updated_at;
-        let needs_refetch = state.needs_refetch;
-
-        // Effect for refetching query on interval.
-        use_timeout(cx, {
-            let needs_refetch = needs_refetch.clone();
-            move || match (updated_at.get(), refetch_interval.get()) {
-                (Some(updated_at), Some(refetch_interval)) => {
-                    let needs_refetch = needs_refetch.clone();
-                    let timeout = time_until_stale(updated_at, refetch_interval);
-                    set_timeout_with_handle(
-                        move || {
-                            needs_refetch.set(true);
-                            resource.refetch();
-                        },
-                        timeout,
-                    )
-                    .ok()
-                }
-                _ => None,
-            }
-        });
-
-        // Refetch query if invalidated.
-        create_isomorphic_effect(cx, {
-            let needs_refetch = needs_refetch.clone();
-            move |_| {
-                if invalidated.get() {
-                    needs_refetch.set(true);
-                    resource.refetch();
-                }
-            }
-        });
-    })
-}
-
-// Will cleanup the cache corresponding to the key when the cache_time has elapsed, and the query has not been updated.
-fn cache_cleanup<K, V>(
-    cx: Scope,
-    key: K,
-    last_updated: Signal<Option<Instant>>,
-    cache_time: Option<Duration>,
-    observers: Rc<Cell<usize>>,
-) where
-    K: Hash + Eq + PartialEq + Clone + 'static,
-    V: 'static,
-{
-    use_timeout(cx, move || match (last_updated.get(), cache_time) {
-        (Some(last_updated), Some(cache_time)) => {
-            let timeout = time_until_stale(last_updated, cache_time);
-            let key = key.clone();
-            let observers = observers.clone();
-            set_timeout_with_handle(
-                move || {
-                    let removed =
-                        use_cache::<K, V, Option<QueryState<K, V>>>(cx, move |(_, cache)| {
-                            cache.remove(&key)
-                        });
-                    if let Some(query) = removed {
-                        if observers.get() == 0 {
-                            query.dispose();
-                            drop(query)
-                        }
-                    };
-                },
-                timeout,
-            )
-            .ok()
-        }
-        _ => None,
-    });
-}
-
-// Ensure that observers are kept track of.
-fn sync_observers<K: Clone, V: Clone>(cx: Scope, state: Memo<QueryState<K, V>>) {
-    type Observer = Rc<Cell<usize>>;
-    let last_observer: Rc<Cell<Option<Observer>>> = Rc::new(Cell::new(None));
-
-    on_cleanup(cx, {
-        let last_observer = last_observer.clone();
-        move || {
-            if let Some(observer) = last_observer.take() {
-                observer.set(observer.get() - 1);
-            }
-        }
-    });
-
-    // Ensure that observers are kept track of.
-    create_isomorphic_effect(cx, move |observers: Option<Rc<Cell<usize>>>| {
-        if let Some(observers) = observers {
-            last_observer.set(None);
-            observers.set(observers.get() - 1);
-        }
-        let observers = state.get().observers;
-        last_observer.set(Some(observers.clone()));
-        observers.set(observers.get() + 1);
-        observers
-    });
-}
-
-fn use_cache<K, V, R>(
-    cx: Scope,
-    func: impl FnOnce((Scope, &mut HashMap<K, QueryState<K, V>>)) -> R + 'static,
-) -> R
-where
-    K: 'static,
-    V: 'static,
-{
-    let client = use_query_client(cx);
-    let mut cache = client.cache.borrow_mut();
-    let entry = cache.entry(TypeId::of::<K>());
-
-    let cache = entry.or_insert_with(|| {
-        let wrapped: CacheEntry<K, V> = Rc::new(RefCell::new(HashMap::new()));
-        let boxed = Box::new(wrapped) as Box<dyn Any>;
-        boxed
-    });
-
-    let mut cache = cache
-        .downcast_ref::<CacheEntry<K, V>>()
-        .expect("Query Cache Type Mismatch.")
-        .borrow_mut();
-
-    func((client.cx, &mut cache))
-}

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -124,16 +124,16 @@ where
     };
 
     let callback = move || resource.refetch();
-    let refetch = create_executor(cx, state, query, callback);
+    let executor = create_executor(cx, state, query, callback);
 
     create_isomorphic_effect(cx, {
-        let refetch = refetch.clone();
+        let executor = executor.clone();
         move |_| {
             let state = state.get();
             let value = state.value.get();
             // Fetch for first time if necessary.
             if state.needs_init() {
-                refetch();
+                executor();
             // Update resource with latest value.
             } else if value.is_some() {
                 resource.set(value);
@@ -150,7 +150,7 @@ where
         (resource.loading().get() || state.fetching.get()) && state.value.get().is_none()
     });
 
-    QueryResult::new(cx, state, data, is_loading, refetch)
+    QueryResult::new(cx, state, data, is_loading, executor)
 }
 
 const LONG_TIME: Duration = Duration::from_secs(60 * 60 * 24);

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -1,7 +1,7 @@
-use crate::instant::Instant;
+use crate::instant::{get_instant, Instant};
 use crate::query_result::QueryResult;
 use crate::util::{time_until_stale, use_timeout};
-use crate::{CacheEntry, QueryClient, QueryOptions, QueryState};
+use crate::{CacheEntry, QueryClient, QueryOptions, QueryState, ResourceOption};
 use leptos::*;
 use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
@@ -71,58 +71,179 @@ pub fn use_query_client(cx: Scope) -> QueryClient {
 ///
 pub fn use_query<K, V, Fu>(
     cx: Scope,
-    key: K,
+    key: impl Fn() -> K + 'static,
     query: impl Fn(K) -> Fu + 'static,
     options: QueryOptions<V>,
 ) -> QueryResult<V>
 where
     Fu: Future<Output = V> + 'static,
     K: Hash + Eq + PartialEq + Clone + 'static,
-    V: Clone + Serializable + 'static,
+    V: std::fmt::Debug + Clone + Serializable + 'static,
 {
-    let cache_time = options.cache_time.clone();
-    let state = use_cache(cx, {
-        let key = key.clone();
-        move |(root_scope, cache)| {
-            let entry = cache.entry(key.clone());
+    let key = create_memo(cx, move |_| key());
 
-            let state = match entry {
-                Entry::Occupied(entry) => {
-                    let entry = entry.into_mut();
-                    entry.set_options(cx, options);
-                    entry
+    // find relevant state.
+    let state = Signal::derive(cx, {
+        let options = options.clone();
+        move || {
+            use_cache(cx, {
+                let options = options.clone();
+                move |(root_scope, cache)| {
+                    let entry = cache.entry(key.get());
+
+                    let state = match entry {
+                        Entry::Occupied(entry) => {
+                            let entry = entry.into_mut();
+                            entry.set_options(cx, options);
+                            entry
+                        }
+                        Entry::Vacant(entry) => {
+                            let state = QueryState::new(root_scope, key.get(), options);
+                            entry.insert(state.clone())
+                        }
+                    };
+                    state.clone()
                 }
-                Entry::Vacant(entry) => {
-                    let state = QueryState::new(root_scope, key.clone(), query, options);
-                    entry.insert(state.clone())
-                }
-            };
-            state.observers.set(state.observers.get() + 1);
-            state.clone()
+            })
         }
     });
 
-    // Keep track of the number of observers for this query.
-    let observers = state.observers.clone();
-    on_cleanup(cx, {
-        let observers = observers.clone();
-        move || {
+    let query = Rc::new(query);
+    let fetcher = move |state: QueryState<K, V>| {
+        let key = key.get();
+        let query = query.clone();
+        async move {
+            state.fetching.set(true);
+            let result = query(key).await;
+            state.updated_at.set(Some(get_instant()));
+            state.fetching.set(false);
+            state.value.set(Some(result.clone()));
+            result
+        }
+    };
+
+    let QueryOptions {
+        default_value,
+        ref resource_option,
+        refetch_interval,
+        ref stale_time,
+        ref cache_time,
+        ..
+    } = options;
+
+    let resource = {
+        match resource_option {
+            ResourceOption::NonBlocking => create_resource(cx, move || state.get(), fetcher),
+            ResourceOption::Blocking => create_blocking_resource(cx, move || state.get(), fetcher),
+        }
+    };
+
+    let read_signal = make_cache_read_signal(cx, state.clone(), resource.clone());
+
+    // Ensure that observers are kept track of.
+    create_isomorphic_effect(cx, move |observers: Option<Rc<Cell<usize>>>| {
+        if let Some(observers) = observers {
             observers.set(observers.get() - 1);
         }
+        state.get().observers
     });
 
-    // Ensure that the Query is removed from cache up after the specified cache_time.
-    let root_scope = use_query_client(cx).cx;
-    cache_cleanup::<K, V>(
-        root_scope,
-        key,
-        state.updated_at.into(),
-        cache_time,
-        observers,
-    );
+    let refetch = move || resource.refetch();
 
-    QueryResult::from_state(cx, state)
+    QueryResult::from_state(cx, state, read_signal, refetch)
 }
+
+pub(crate) fn make_cache_read_signal<K, V>(
+    cx: Scope,
+    state: Signal<QueryState<K, V>>,
+    resource: Resource<QueryState<K, V>, V>,
+) -> Signal<Option<V>>
+where
+    K: Clone,
+    V: Clone + std::fmt::Debug,
+{
+    create_isomorphic_effect(cx, move |_| {
+        let state = state.get();
+
+        let invalidated = state.invalidated;
+        let refetch_interval = state.refetch_interval;
+        let updated_at = state.updated_at;
+
+        let refetch = move || {
+            if updated_at.get_untracked().is_some() {
+                if !resource.loading().get_untracked() {
+                    resource.refetch();
+                    invalidated.set(false);
+                }
+            }
+        };
+        let refetch = store_value(cx, refetch);
+
+        // Effect for refetching query on interval.
+        use_timeout(cx, move || {
+            match (updated_at.get(), refetch_interval.get()) {
+                (Some(updated_at), Some(refetch_interval)) => {
+                    let timeout = time_until_stale(updated_at, refetch_interval);
+                    set_timeout_with_handle(
+                        move || {
+                            refetch.with_value(|r| r());
+                        },
+                        timeout,
+                    )
+                    .ok()
+                }
+                _ => None,
+            }
+        });
+
+        // Refetch query if invalidated.
+        create_isomorphic_effect(cx, {
+            move |_| {
+                if invalidated.get() {
+                    refetch.with_value(|r| r());
+                }
+            }
+        });
+    });
+
+    Signal::derive(cx, move || {
+        let state = state.get();
+        let stale_time = state.stale_time;
+        let updated_at = state.updated_at;
+        let invalidated = state.invalidated;
+
+        // On mount, ensure that the resource is not stale.
+        match (updated_at.get_untracked(), stale_time.get_untracked()) {
+            (Some(updated_at), Some(stale_time)) => {
+                if time_until_stale(updated_at, stale_time).is_zero() {
+                    if !resource.loading().get_untracked() {
+                        resource.refetch();
+                        invalidated.set(false);
+                    }
+                }
+            }
+            _ => (),
+        }
+
+        // Happens when the resource is SSR'd.
+        let read = resource.read(cx);
+        if read.is_some() && updated_at.get_untracked().is_none() {
+            updated_at.set(Some(get_instant()));
+        }
+
+        read
+    })
+}
+
+// Ensure that the Query is removed from cache up after the specified cache_time.
+// let root_scope = use_query_client(cx).cx;
+// cache_cleanup::<K, V>(
+//     root_scope,
+//     key,
+//     state.updated_at.into(),
+//     cache_time,
+//     observers,
+// );
 
 // Will cleanup the cache corresponding to the key when the cache_time has elapsed, and the query has not been updated.
 fn cache_cleanup<K, V>(

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -182,6 +182,7 @@ where
         }
     });
 
+    // Doing this outside of QueryResult because of the need for `resource`.
     let is_loading = Signal::derive(cx, move || {
         let state = state.get();
 
@@ -202,6 +203,7 @@ async fn sleep(duration: Duration) {
         } else if #[cfg(feature = "ssr")] {
             tokio::time::sleep(duration).await;
         } else {
+            let _ = duration;
             debug_warn!("You are missing a Cargo feature for leptos_query. Please use one of 'ssr' or 'hydrate'")
         }
     }

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -1,7 +1,7 @@
-use crate::instant::{get_instant, Instant};
+use crate::instant::Instant;
 use crate::query_result::QueryResult;
 use crate::util::{time_until_stale, use_timeout};
-use crate::{CacheEntry, QueryClient, QueryOptions, QueryState, ResourceOption};
+use crate::{CacheEntry, QueryClient, QueryOptions, QueryState};
 use leptos::*;
 use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
@@ -56,7 +56,7 @@ pub fn use_query_client(cx: Scope) -> QueryClient {
 ///     leptos_query::use_query(
 ///         cx,
 ///         id,
-///         |id| async move { get_monkey(id).await },
+///         get_monkey,
 ///         QueryOptions {
 ///             default_value: None,
 ///             refetch_interval: None,
@@ -80,16 +80,22 @@ where
     K: Hash + Eq + PartialEq + Clone + 'static,
     V: std::fmt::Debug + Clone + Serializable + 'static,
 {
-    let key = create_memo(cx, move |_| key());
+    // TODO: this should probably be memo?
+    // If I use memo here, then I get 'not being used in reactive context' warnings.
+    // let key = create_memo(cx, move |_| key());
+    let key = Signal::derive(cx, move || key());
+    let query = Rc::new(query);
 
     // find relevant state.
     let state = Signal::derive(cx, {
         let options = options.clone();
         move || {
+            let key = key.get();
             use_cache(cx, {
                 let options = options.clone();
+                let query = query.clone();
                 move |(root_scope, cache)| {
-                    let entry = cache.entry(key.get());
+                    let entry = cache.entry(key.clone());
 
                     let state = match entry {
                         Entry::Occupied(entry) => {
@@ -98,7 +104,7 @@ where
                             entry
                         }
                         Entry::Vacant(entry) => {
-                            let state = QueryState::new(root_scope, key.get(), options);
+                            let state = QueryState::new(root_scope, key.clone(), query, options);
                             entry.insert(state.clone())
                         }
                     };
@@ -108,142 +114,26 @@ where
         }
     });
 
-    let query = Rc::new(query);
-    let fetcher = move |state: QueryState<K, V>| {
-        let key = key.get();
-        let query = query.clone();
-        async move {
-            state.fetching.set(true);
-            let result = query(key).await;
-            state.updated_at.set(Some(get_instant()));
-            state.fetching.set(false);
-            state.value.set(Some(result.clone()));
-            result
-        }
-    };
+    sync_observers(cx, state.clone());
 
-    let QueryOptions {
-        default_value,
-        ref resource_option,
-        refetch_interval,
-        ref stale_time,
-        ref cache_time,
-        ..
-    } = options;
-
-    let resource = {
-        match resource_option {
-            ResourceOption::NonBlocking => create_resource(cx, move || state.get(), fetcher),
-            ResourceOption::Blocking => create_blocking_resource(cx, move || state.get(), fetcher),
-        }
-    };
-
-    let read_signal = make_cache_read_signal(cx, state.clone(), resource.clone());
-
-    // Ensure that observers are kept track of.
-    create_isomorphic_effect(cx, move |observers: Option<Rc<Cell<usize>>>| {
-        if let Some(observers) = observers {
-            observers.set(observers.get() - 1);
-        }
-        state.get().observers
-    });
-
-    let refetch = move || resource.refetch();
-
-    QueryResult::from_state(cx, state, read_signal, refetch)
-}
-
-pub(crate) fn make_cache_read_signal<K, V>(
-    cx: Scope,
-    state: Signal<QueryState<K, V>>,
-    resource: Resource<QueryState<K, V>, V>,
-) -> Signal<Option<V>>
-where
-    K: Clone,
-    V: Clone + std::fmt::Debug,
-{
+    // Ensure that the Query is removed from cache up after the specified cache_time.
+    let root_scope = use_query_client(cx).cx;
+    let cache_time = options.cache_time;
     create_isomorphic_effect(cx, move |_| {
         let state = state.get();
-
-        let invalidated = state.invalidated;
-        let refetch_interval = state.refetch_interval;
-        let updated_at = state.updated_at;
-
-        let refetch = move || {
-            if updated_at.get_untracked().is_some() {
-                if !resource.loading().get_untracked() {
-                    resource.refetch();
-                    invalidated.set(false);
-                }
-            }
-        };
-        let refetch = store_value(cx, refetch);
-
-        // Effect for refetching query on interval.
-        use_timeout(cx, move || {
-            match (updated_at.get(), refetch_interval.get()) {
-                (Some(updated_at), Some(refetch_interval)) => {
-                    let timeout = time_until_stale(updated_at, refetch_interval);
-                    set_timeout_with_handle(
-                        move || {
-                            refetch.with_value(|r| r());
-                        },
-                        timeout,
-                    )
-                    .ok()
-                }
-                _ => None,
-            }
-        });
-
-        // Refetch query if invalidated.
-        create_isomorphic_effect(cx, {
-            move |_| {
-                if invalidated.get() {
-                    refetch.with_value(|r| r());
-                }
-            }
-        });
+        let observers = state.observers.clone();
+        let key = key.get();
+        cache_cleanup::<K, V>(
+            root_scope,
+            key,
+            state.updated_at.into(),
+            cache_time,
+            observers,
+        );
     });
 
-    Signal::derive(cx, move || {
-        let state = state.get();
-        let stale_time = state.stale_time;
-        let updated_at = state.updated_at;
-        let invalidated = state.invalidated;
-
-        // On mount, ensure that the resource is not stale.
-        match (updated_at.get_untracked(), stale_time.get_untracked()) {
-            (Some(updated_at), Some(stale_time)) => {
-                if time_until_stale(updated_at, stale_time).is_zero() {
-                    if !resource.loading().get_untracked() {
-                        resource.refetch();
-                        invalidated.set(false);
-                    }
-                }
-            }
-            _ => (),
-        }
-
-        // Happens when the resource is SSR'd.
-        let read = resource.read(cx);
-        if read.is_some() && updated_at.get_untracked().is_none() {
-            updated_at.set(Some(get_instant()));
-        }
-
-        read
-    })
+    QueryResult::from_state_signal(cx, state)
 }
-
-// Ensure that the Query is removed from cache up after the specified cache_time.
-// let root_scope = use_query_client(cx).cx;
-// cache_cleanup::<K, V>(
-//     root_scope,
-//     key,
-//     state.updated_at.into(),
-//     cache_time,
-//     observers,
-// );
 
 // Will cleanup the cache corresponding to the key when the cache_time has elapsed, and the query has not been updated.
 fn cache_cleanup<K, V>(
@@ -279,6 +169,33 @@ fn cache_cleanup<K, V>(
             .ok()
         }
         _ => None,
+    });
+}
+
+// Ensure that observers are kept track of.
+fn sync_observers<K: Clone, V: Clone>(cx: Scope, state: Signal<QueryState<K, V>>) {
+    type Observer = Rc<Cell<usize>>;
+    let last_observer: Rc<Cell<Option<Observer>>> = Rc::new(Cell::new(None));
+
+    on_cleanup(cx, {
+        let last_observer = last_observer.clone();
+        move || {
+            if let Some(observer) = last_observer.take() {
+                observer.set(observer.get() - 1);
+            }
+        }
+    });
+
+    // Ensure that observers are kept track of.
+    create_isomorphic_effect(cx, move |observers: Option<Rc<Cell<usize>>>| {
+        if let Some(observers) = observers {
+            last_observer.set(None);
+            observers.set(observers.get() - 1);
+        }
+        let observers = state.get().observers;
+        last_observer.set(Some(observers.clone()));
+        observers.set(observers.get() + 1);
+        observers
     });
 }
 

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -124,22 +124,14 @@ where
         }
     };
 
-    let callback = move || {
-        // Interrupt suspense.
-        if resource.loading().get_untracked() {
-            resource.set(state.get_untracked().value.get_untracked());
-        } else {
-            resource.refetch();
-        }
-    };
-
-    let executor = create_executor(cx, state, query, callback);
+    let executor = create_executor(cx, state, query);
 
     // Ensure always latest value.
     create_isomorphic_effect(cx, move |_| {
         let state = state.get();
         let value = state.value.get();
         if value.is_some() {
+            // Interrupt suspense.
             if resource.loading().get_untracked() {
                 resource.set(value);
             } else {


### PR DESCRIPTION
`use_query` now works with a reactive key.

Many ideas were used from Tanstack Query. The main takeaway that I got from reading source code from tanstack/query is the Resource created in `use_query` should not execute the provided async query function. 

This makes it impossible to de-duplicate the same query in different parts of the application, which is a killer feature. 

Instead the Resource should simply synchronize with the query state. 

The resource should suspend (async timeout never resolving) if the query is loading. if it's not loading then just get the latest value. 

Then in an effect, interrupt the resource if it is loading by setting the resource directly (SignalSet).

So the initial resource resolution works like this:

resource reads state, state is not present
resource is suspended
executor executes the query using `spawn_local`
executor then sets the state of the query
executor then calls resource.refetch 
resource reads the new state 


--- 
**NOTES**

The only *known* quirk with the current implementation is the following:

When the key changes and the data for the new key hasn't been fetched yet, the fallback view in a `<Transition/>` is not re-triggered. Meaning you will see the old data for the previous key until the new data comes in. 