### PR TITLE
Query Client Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/leptos_query.svg)](https://crates.io/crates/leptos_query)
 [![docs.rs](https://docs.rs/leptos_query/badge.svg)](https://docs.rs/leptos_query)
+[![Logo](/logo.svg)](https://docs.rs/leptos_query)
 
 ## About
 
@@ -32,7 +33,7 @@ Leptos Query focuses on simplifying your data fetching process and keeping your 
 ## Installation
 
 ```bash
-cargo add leptos_query --optional
+cargo add leptos_query
 ```
 
 Then add the relevant feature(s) to your `Cargo.toml`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [![Crates.io](https://img.shields.io/crates/v/leptos_query.svg)](https://crates.io/crates/leptos_query)
 [![docs.rs](https://docs.rs/leptos_query/badge.svg)](https://docs.rs/leptos_query)
-[![Logo](/logo.svg)](https://docs.rs/leptos_query)
+
+<p align="center">
+    <a href="https://docs.rs/leptos_query">
+        <img src="https://raw.githubusercontent.com/nicoburniske/leptos_query/main/logo.svg" alt="Leptos Query" width="150"/>
+    </a>
+</p>
 
 ## About
 

--- a/example/start-axum/Cargo.toml
+++ b/example/start-axum/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.38"
 tracing = { version = "0.1.37", optional = true }
 http = "0.2.8"
 serde = "1.0.171"
-leptos_query = { path = "../../", optional = true}
+leptos_query = { path = "../../"}
 
 [features]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate", "leptos_query/hydrate"]
@@ -66,10 +66,10 @@ style-file = "style/main.scss"
 assets-dir = "public"
 
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-addr = "127.0.0.1:3000"
+site-addr = "127.0.0.1:3005"
 
 # The port to use for automatic reload monitoring
-reload-port = 3001
+reload-port = 3006
 
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 #   [Windows] for non-WSL use "npx.cmd playwright test"

--- a/example/start-axum/Cargo.toml
+++ b/example/start-axum/Cargo.toml
@@ -66,10 +66,10 @@ style-file = "style/main.scss"
 assets-dir = "public"
 
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-addr = "127.0.0.1:3005"
+site-addr = "127.0.0.1:3000"
 
 # The port to use for automatic reload monitoring
-reload-port = 3006
+reload-port = 3001
 
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 #   [Windows] for non-WSL use "npx.cmd playwright test"

--- a/example/start-axum/src/lib.rs
+++ b/example/start-axum/src/lib.rs
@@ -2,6 +2,7 @@ use cfg_if::cfg_if;
 pub mod app;
 pub mod error_template;
 pub mod fileserv;
+pub mod todo;
 
 cfg_if! { if #[cfg(feature = "hydrate")] {
     use leptos::*;

--- a/example/start-axum/src/todo.rs
+++ b/example/start-axum/src/todo.rs
@@ -1,0 +1,256 @@
+use leptos::*;
+use leptos_query::*;
+use leptos_router::ActionForm;
+use std::{sync::RwLock, time::Duration};
+
+use serde::*;
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Todo {
+    id: u32,
+    content: String,
+}
+
+#[component]
+pub fn InteractiveTodo(cx: Scope) -> impl IntoView {
+    view! { cx,
+        <div>
+            <div style:display="flex" style:gap="10rem">
+                <TodoWithResource/>
+                <TodoWithQuery/>
+            </div>
+            <AddTodoComponent/>
+            <AllTodos/>
+        </div>
+    }
+}
+
+#[component]
+fn TodoWithResource(cx: Scope) -> impl IntoView {
+    let (todo_id, set_todo_id) = create_signal(cx, 0_u32);
+
+    // todo_id is a Signal<String>, and that is fed into the resource fetcher function.
+    // any time todo_id changes, the resource will re-execute.
+    let todo_resource: Resource<u32, Option<Todo>> =
+        create_resource(cx, todo_id, |id| async move { get_todo(id).await.unwrap() });
+
+    let todo = Signal::derive(cx, move || todo_resource.read(cx));
+
+    view! { cx,
+        <div
+            style:display="flex"
+            style:flex-direction="column"
+            style:justify-content="between"
+            style:align-items="center"
+            style:height="30vh"
+        >
+            <h2>"Todo with Resource" </h2>
+            <label>"Todo ID"</label>
+            <input
+                type="number"
+                on:input=move |ev| {
+                    if let Ok(todo_id) = event_target_value(&ev).parse() {
+                        set_todo_id(todo_id);
+                    }
+                }
+                prop:value=todo_id
+            />
+            <Transition fallback=move || {
+                view! { cx, <p>"Loading..."</p> }
+            }>
+                <p>
+                    {move || {
+                        todo.get()
+                            .map(|a| {
+                                match a {
+                                    Some(todo) => todo.content,
+                                    None => "Not found".into(),
+                                }
+                            })
+                    }}
+                </p>
+            </Transition>
+        </div>
+    }
+}
+
+#[component]
+fn TodoWithQuery(cx: Scope) -> impl IntoView {
+    let (todo_id, set_todo_id) = create_signal(cx, 0_u32);
+
+    let QueryResult { data, .. } = use_query(
+        cx,
+        todo_id,
+        |id| async move { get_todo(id).await.unwrap() },
+        QueryOptions::default(),
+    );
+
+    view! { cx,
+        <div
+            style:display="flex"
+            style:flex-direction="column"
+            style:justify-content="between"
+            style:align-items="center"
+            style:height="30vh"
+        >
+            <h2>"Todo with Query" </h2>
+            <label>"Todo ID"</label>
+            <input
+                type="number"
+                on:input=move |ev| {
+                    if let Ok(todo_id) = event_target_value(&ev).parse() {
+                        set_todo_id(todo_id);
+                    }
+                }
+                prop:value=todo_id
+            />
+            <Transition fallback=move || {
+                view! { cx, <p>"Loading..."</p> }
+            }>
+                <p>
+                    {move || {
+                        data.get()
+                            .map(|a| {
+                                match a {
+                                    Some(todo) => todo.content,
+                                    // This case breaks the hydration on SSR.
+                                    None => "Not found".into(),
+                                }
+                            })
+                    }}
+                </p>
+            </Transition>
+        </div>
+    }
+}
+
+// When using this, you get a ton of hydration errors.
+#[component]
+fn TodoBody(cx: Scope, todo: Signal<Option<Option<Todo>>>) -> impl IntoView {
+    view! { cx,
+        <Suspense fallback=move || {
+            view! { cx, <p>"Loading..."</p> }
+        }>
+            <p>
+                {move || {
+                    todo.get()
+                        .map(|a| {
+                            match a {
+                                Some(todo) => todo.content,
+                                None => "Not found".into(),
+                            }
+                        })
+                }}
+            </p>
+        </Suspense>
+    }
+}
+
+#[component]
+fn AllTodos(cx: Scope) -> impl IntoView {
+    let QueryResult { data, refetch, .. } = use_query(
+        cx,
+        || (),
+        |_| async move { get_todos().await.unwrap_or_default() },
+        QueryOptions::default(),
+    );
+
+    let todos: Signal<Vec<Todo>> = Signal::derive(cx, move || data.get().unwrap_or_default());
+
+    let delete_todo = create_action(cx, move |id: &u32| {
+        let id = *id;
+        let refetch = refetch.clone();
+        async move {
+            let _ = delete_todo(id.clone()).await;
+            refetch();
+            use_query_client(cx).invalidate_query::<u32, Option<Todo>>(&id);
+        }
+    });
+
+    view! { cx,
+        <h2>"All Todos"</h2>
+        <Suspense fallback=move || {
+            view! { cx, <p>"Loading..."</p> }
+        }>
+            <ul>
+                <For
+                    each=todos
+                    key=|todo| todo.id
+                    view=move |cx, todo| {
+                        view! { cx,
+                            <li>
+                                <span>{todo.id}</span>
+                                <span>": "</span>
+                                <span>{todo.content}</span>
+                                <span>" "</span>
+                                <button on:click=move |_| delete_todo.dispatch(todo.id) >
+                                    "X"
+                                </button>
+                            </li>
+                        }
+                    }
+                />
+            </ul>
+        </Suspense>
+    }
+}
+
+#[component]
+fn AddTodoComponent(cx: Scope) -> impl IntoView {
+    let add_todo = create_server_action::<AddTodo>(cx);
+
+    let response = add_todo.value();
+
+    let client = use_query_client(cx);
+
+    create_effect(cx, move |_| {
+        if response.get().is_some() {
+            client.clone().invalidate_all_queries::<u32, Option<Todo>>();
+            client.clone().invalidate_all_queries::<(), Vec<Todo>>();
+        }
+    });
+
+    view! { cx,
+        <ActionForm action=add_todo>
+            <label>"Add a Todo " <input type="text" name="content"/></label>
+            <input type="submit" value="Add"/>
+        </ActionForm>
+    }
+}
+
+#[cfg(feature = "ssr")]
+static GLOBAL_TODOS: RwLock<Vec<Todo>> = RwLock::new(vec![]);
+
+#[server(GetTodo, "/api")]
+async fn get_todo(id: u32) -> Result<Option<Todo>, ServerFnError> {
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    let todos = GLOBAL_TODOS.read().unwrap();
+    Ok(todos.iter().find(|t| t.id == id).cloned())
+}
+
+#[server(GetTodos, "/api")]
+pub async fn get_todos() -> Result<Vec<Todo>, ServerFnError> {
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    let todos = GLOBAL_TODOS.read().unwrap();
+    Ok(todos.clone())
+}
+
+#[server(DeleteTodo, "/api")]
+async fn delete_todo(id: u32) -> Result<(), ServerFnError> {
+    let mut todos = GLOBAL_TODOS.write().unwrap();
+    todos.retain(|t| t.id != id);
+    Ok(())
+}
+
+#[server(AddTodo, "/api")]
+pub async fn add_todo(content: String) -> Result<(), ServerFnError> {
+    let mut todos = GLOBAL_TODOS.write().unwrap();
+
+    let new_id = todos.last().map(|t| t.id + 1).unwrap_or(0);
+
+    todos.push(Todo {
+        id: new_id as u32,
+        content,
+    });
+
+    Ok(())
+}

--- a/example/start-axum/src/todo.rs
+++ b/example/start-axum/src/todo.rs
@@ -151,7 +151,7 @@ fn AllTodos(cx: Scope) -> impl IntoView {
         let id = *id;
         let refetch = refetch.clone();
         async move {
-            let _ = delete_todo(id.clone()).await;
+            let _ = delete_todo(id).await;
             refetch();
             use_query_client(cx).invalidate_query::<u32, TodoResponse>(&id);
         }
@@ -203,10 +203,10 @@ fn AddTodoComponent(cx: Scope) -> impl IntoView {
         if let Some(Ok(todo)) = response.get() {
             let id = todo.id;
             // Invalidate individual TodoResponse.
-            client.clone().invalidate_query::<u32, TodoResponse>(&id);
+            client.clone().invalidate_query::<u32, TodoResponse>(id);
 
             // Invalidate AllTodos.
-            client.clone().invalidate_all_queries::<(), Vec<Todo>>();
+            client.clone().invalidate_query::<(), Vec<Todo>>(());
 
             // Optimistic update.
             let as_response = Ok(Some(todo));

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:bx="https://boxy-svg.com" viewBox="0 0 150 150">
+  <path style="fill: rgb(225, 57, 58); stroke: rgb(225, 57, 58); transform-origin: 635.573px 425.059px;" transform="matrix(0, 0.553396105766, -0.527471005917, 0, -560.573236640971, -348.615171066835)" d="M 536.187 380.992 A 104.271 104.271 0 1 1 536.187 469.126 A 46.968 46.968 0 1 0 536.187 380.992 Z" bx:shape="crescent 630.689 425.059 104.271 310 0.35 1@7be5f068"/>
+  <rect style="stroke: rgb(0, 0, 0); transform-origin: -75.0005px -72.918px;" x="-84.599" y="-105.632" width="19.197" height="65.428" rx="9.6" ry="9.6" transform="matrix(-1, 0, 0, -1, 150.000991821289, 145.835998535156)"/>
+  <ellipse style="fill: rgb(250, 249, 246); stroke: rgb(0, 0, 0); stroke-width: 15px; transform-origin: -75px -31.556px;" cx="-75" cy="-31.556" rx="13" ry="13" transform="matrix(-1, 0, 0, -1, 150, 63.111999511719)"/>
+  <ellipse style="stroke: rgb(255, 255, 255); fill: rgb(255, 255, 255); transform-origin: -75px -106.556px;" cx="-75" cy="-106.556" rx="8" ry="8" transform="matrix(-1, 0, 0, -1, 150, 213.111999511719)"/>
+</svg>

--- a/src/query.rs
+++ b/src/query.rs
@@ -56,9 +56,12 @@ where
     V: Clone + 'static,
 {
     /// Marks the resource as invalid, which will cause it to be refetched on next read.
-    pub(crate) fn mark_invalid(&self) {
+    pub(crate) fn mark_invalid(&self) -> bool {
         if let QueryState::Loaded(data) = self.state.get_untracked() {
-            self.state.set(QueryState::Invalid(data))
+            self.state.set(QueryState::Invalid(data));
+            true
+        } else {
+            false
         }
     }
 

--- a/src/query_executor.rs
+++ b/src/query_executor.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use crate::{
-    evict_and_notify,
     query::Query,
     use_query_client,
     util::{maybe_time_until_stale, time_until_stale, use_timeout},
@@ -255,7 +254,7 @@ where
                                     let query = query.clone();
                                     move || {
                                         let removed =
-                                            evict_and_notify::<K, V>(root_scope, query.key);
+                                            use_query_client(root_scope).evict_and_notify::<K, V>(&query.key);
                                         if let Some(query) = removed {
                                             if query.observers.get() == 0 {
                                                 query.dispose();

--- a/src/query_state.rs
+++ b/src/query_state.rs
@@ -83,6 +83,16 @@ pub struct QueryData<V> {
     pub updated_at: Instant,
 }
 
+impl<V> QueryData<V> {
+    /// Creates a new QueryData with the given data and the current time as the updated_at timestamp.
+    pub fn now(data: V) -> Self {
+        Self {
+            data,
+            updated_at: Instant::now(),
+        }
+    }
+}
+
 impl<V> std::fmt::Debug for QueryData<V>
 where
     V: std::fmt::Debug,

--- a/src/use_query.rs
+++ b/src/use_query.rs
@@ -1,7 +1,7 @@
 use crate::query_executor::{create_executor, synchronize_state};
 use crate::query_result::QueryResult;
 use crate::{
-    create_query_result, get_query_signal, Query, QueryData, QueryOptions, QueryState, RefetchFn,
+    create_query_result, use_query_client, Query, QueryData, QueryOptions, QueryState, RefetchFn,
     ResourceOption,
 };
 use leptos::*;
@@ -68,7 +68,7 @@ where
     Fu: Future<Output = V> + 'static,
 {
     // Find relevant state.
-    let query = get_query_signal(cx, key);
+    let query = use_query_client(cx).get_query_signal(cx, key);
 
     // Update options.
     create_isomorphic_effect(cx, {


### PR DESCRIPTION
Bug Fix:
- Enables Invalidation to happen on active query without BorrowError.
   - Add create_memo properly to avoid borrowed exception on state signal


QueryClient Changes:
- Added `invalidate_query_type` and `invalidate_all` methods 
- Removed redundant`set_query_data_now`
- Improve ergonomics of methods using std::borrow::Borrow
- Add examples to docs
- Added more unit tests

Added TODO Example

Improved README + Added Logo

