### PR TITLE
Fix spawn local outside localset

### DIFF
--- a/example/start-axum/src/main.rs
+++ b/example/start-axum/src/main.rs
@@ -4,6 +4,7 @@ async fn main() {
     use axum::{routing::post, Router};
     use leptos::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_query::with_query_supression;
     use start_axum::app::*;
     use start_axum::fileserv::file_and_error_handler;
     use tokio::net::TcpListener;
@@ -18,7 +19,8 @@ async fn main() {
     let conf = get_configuration(None).await.unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
-    let routes = generate_route_list(App);
+
+    let routes = with_query_supression(|| generate_route_list(App));
 
     // build our application with a route
     let app = Router::new()

--- a/query/src/query.rs
+++ b/query/src/query.rs
@@ -12,6 +12,7 @@ use leptos::*;
 use crate::{
     garbage_collector::GarbageCollector,
     query_cache::CacheNotification,
+    query_is_supressed,
     query_observer::{ObserverKey, QueryObserver},
     use_query_client,
     util::time_until_stale,
@@ -224,7 +225,9 @@ where
         let fetcher = observers.values().find_map(|f| f.get_fetcher());
 
         if let Some(fetcher) = fetcher {
-            spawn_local(execute_query(self.clone(), move |k| fetcher(k)));
+            if !query_is_supressed() {
+                spawn_local(execute_query(self.clone(), move |k| fetcher(k)));
+            }
         }
     }
 

--- a/query/src/query_cache.rs
+++ b/query/src/query_cache.rs
@@ -264,6 +264,7 @@ impl QueryCache {
         }
         // Though persister receives removal events, there may be queries in persister that are not yet in cache.
         // So we should clear them all.
+        #[cfg(any(feature = "hydrate", feature = "csr"))]
         if let Some(persister) = self.persister.borrow().clone() {
             spawn_local(async move {
                 persister.clear().await;

--- a/query/src/query_executor.rs
+++ b/query/src/query_executor.rs
@@ -23,12 +23,37 @@ use std::cell::Cell;
 /// fn App() -> impl IntoView {
 ///     ()
 /// }
-///
-///
-///
 /// ```
 pub fn suppress_query_load(suppress: bool) {
     SUPPRESS_QUERY_LOAD.with(|w| w.set(suppress));
+}
+
+/// Run a closure with query loading suppressed.
+///
+/// Useful for disabling query loads during App introspection, such as SSR Router integrations for Actix/Axum.
+///
+/// Example for `generate_route_list`
+/// ```
+/// use leptos::*;
+/// use leptos_query::*;
+/// use leptos_axum::*;
+///
+/// fn make_routes()  {
+///    let routes = with_query_supression(|| generate_route_list(App));
+/// }
+///
+/// #[component]
+/// fn App() -> impl IntoView {
+///     ()
+/// }
+/// ```
+pub fn with_query_supression<T>(f: impl FnOnce() -> T) -> T {
+    SUPPRESS_QUERY_LOAD.with(|w| {
+        w.set(true);
+        let result = f();
+        w.set(false);
+        result
+    })
 }
 
 pub(crate) fn query_is_supressed() -> bool {

--- a/query/src/query_persister.rs
+++ b/query/src/query_persister.rs
@@ -21,8 +21,9 @@ where
 {
     fn process_cache_event(&self, event: CacheEvent) {
         match event {
+            #[cfg(any(feature = "hydrate", feature = "csr"))]
             CacheEvent::Created(query) => {
-                if let Ok(value) = query.state.try_into() {
+                if let Ok(value) = TryInto::<PersistQueryData>::try_into(query.state) {
                     let key = query.key.0;
                     let persister = self.clone();
                     leptos::spawn_local(async move {
@@ -30,8 +31,9 @@ where
                     })
                 }
             }
+            #[cfg(any(feature = "hydrate", feature = "csr"))]
             CacheEvent::Updated(query) => {
-                if let Ok(value) = query.state.try_into() {
+                if let Ok(value) = TryInto::<PersistQueryData>::try_into(query.state) {
                     let key = query.key.0;
                     let persister = self.clone();
                     leptos::spawn_local(async move {
@@ -39,6 +41,7 @@ where
                     })
                 }
             }
+            #[cfg(any(feature = "hydrate", feature = "csr"))]
             CacheEvent::Removed(key) => {
                 let persister = self.clone();
                 leptos::spawn_local(async move {
@@ -115,6 +118,7 @@ pub mod local_storage_persister {
 
     #[cfg(any(feature = "hydrate", feature = "csr"))]
     thread_local! {
+        #[cfg(any(feature = "hydrate", feature = "csr"))]
         pub(crate) static LOCAL_STORAGE: Option<web_sys::Storage> = leptos::window().local_storage().ok().flatten()
     }
 

--- a/query/src/use_query.rs
+++ b/query/src/use_query.rs
@@ -1,7 +1,9 @@
 use crate::query::Query;
 use crate::query_observer::{ListenerKey, QueryObserver};
 use crate::query_result::QueryResult;
-use crate::{use_query_client, QueryOptions, QueryState, RefetchFn, ResourceOption};
+use crate::{
+    query_is_supressed, use_query_client, QueryOptions, QueryState, RefetchFn, ResourceOption,
+};
 use leptos::*;
 use std::cell::Cell;
 use std::future::Future;
@@ -111,7 +113,10 @@ where
     // Ensure latest data in resource.
     create_isomorphic_effect(move |_| {
         query_state.track();
-        resource.refetch();
+        // If query is supressed, we have to make sure we don't refetch to avoid calling spawn_local.
+        if !query_is_supressed() {
+            resource.refetch();
+        }
     });
 
     let data = Signal::derive({


### PR DESCRIPTION
If you have a resource in your root route, then the following panic happened.

```
thread 'main' panicked at /Users/nicoburniske/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptos_reactive-0.6.5/src/spawn.rs:90:13:
`spawn_local` called from outside of a `task::LocalSet`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at /rustc/714b29a17ff5fa727c794bbb60bfd335f8e75d42/library/std/src/thread/local.rs:262:26:
cannot access a Thread Local Storage value during or after destruction: AccessError
fatal runtime error: thread local panicked on drop
```

The main problem is this effect in `use_query`

```rust
    // Ensure latest data in resource.
    create_isomorphic_effect(move |_| {
        query_state.track();
        resource.refetch();
    });
```

The fix is to add a suppression check to the refetch call. Those are not protected by `suppress_resource_load` in leptos

```rust
   // Ensure latest data in resource.
    create_isomorphic_effect(move |_| {
        query_state.track();
        // If query is supressed, we have to make sure we don't refetch to avoid calling spawn_local.
        if !query_is_suppressed() {
            resource.refetch();
        }
    });

```